### PR TITLE
dev - Square's expects an empty body on GET

### DIFF
--- a/lib/square_up/client.ex
+++ b/lib/square_up/client.ex
@@ -99,6 +99,7 @@ defmodule SquareUp.Client do
   end
 
   defp body(_client, %{method: :delete}), do: ""
+  defp body(_client, %{method: :get}), do: ""
 
   defp body(_client, call) do
     Jason.encode!(call.params)


### PR DESCRIPTION
Hi!  I'm so excited to have found your library.  Trying to get it working in a project and I was getting errors from Square about an unexpected body for a GET request.  Passing "" fixes it.