### PR TITLE
Adds query params to functions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+erlang 22.3.4.3
+elixir 1.10
+nodejs 12.18.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 erlang 22.3.4.3
-elixir 1.10
+elixir 1.11
 nodejs 12.18.2

--- a/lib/square_up/client.ex
+++ b/lib/square_up/client.ex
@@ -18,7 +18,8 @@ defmodule SquareUp.Client do
     import Norm
 
     with {:ok, _params} <- conform(call.params, call.params_spec),
-         {:ok, _params} <- conform(call.path_params, call.path_params_spec) do
+         {:ok, _params} <- conform(call.path_params, call.path_params_spec),
+         {:ok, _params} <- conform(call.query_params, call.query_params_spec) do
       :ok
     else
       {:error, _} = err -> err
@@ -86,7 +87,9 @@ defmodule SquareUp.Client do
         String.replace(path, "{#{key}}", val)
       end)
 
-    client.base_path <> path
+    query = URI.encode_query(call.query_params)
+
+    client.base_path <> path <> "?" <> query
   end
 
   defp headers(client, _call) do

--- a/lib/square_up/resources/mobile/mobile_authorization_code.ex
+++ b/lib/square_up/resources/mobile/mobile_authorization_code.ex
@@ -5,11 +5,13 @@ defmodule SquareUp.MOBILE.MobileAuthorizationCode do
   @spec create(
           SquareUp.Client.t(),
           %{},
+          %{},
           SquareUp.TypeSpecs.create_mobile_authorization_code_request()
         ) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_mobile_authorization_code_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.create_mobile_authorization_code_request/0)
@@ -20,8 +22,10 @@ defmodule SquareUp.MOBILE.MobileAuthorizationCode do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/mobile/authorization-code"

--- a/lib/square_up/resources/mobile/mobile_authorization_code.ex
+++ b/lib/square_up/resources/mobile/mobile_authorization_code.ex
@@ -5,16 +5,17 @@ defmodule SquareUp.MOBILE.MobileAuthorizationCode do
   @spec create(
           SquareUp.Client.t(),
           %{},
-          %{},
-          SquareUp.TypeSpecs.create_mobile_authorization_code_request()
+          SquareUp.TypeSpecs.create_mobile_authorization_code_request(),
+          %{}
         ) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_mobile_authorization_code_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.create_mobile_authorization_code_request/0)
+
+    query_params_spec = schema(%{})
 
     response_spec =
       {:delegate, &SquareUp.ResponseSchema.create_mobile_authorization_code_response/0}
@@ -22,11 +23,11 @@ defmodule SquareUp.MOBILE.MobileAuthorizationCode do
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/mobile/authorization-code"
     })

--- a/lib/square_up/resources/oauth2/token.ex
+++ b/lib/square_up/resources/oauth2/token.ex
@@ -2,45 +2,45 @@ defmodule SquareUp.OAUTH2.Token do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec obtain(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.obtain_token_request()) ::
+  @spec obtain(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.obtain_token_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.obtain_token_response())
-  def obtain(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def obtain(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.obtain_token_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.obtain_token_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/oauth2/token"
     })
   end
 
-  @spec revoke(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.revoke_token_request()) ::
+  @spec revoke(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.revoke_token_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.revoke_token_response())
-  def revoke(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def revoke(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.revoke_token_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.revoke_token_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/oauth2/revoke"
     })

--- a/lib/square_up/resources/oauth2/token.ex
+++ b/lib/square_up/resources/oauth2/token.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.OAUTH2.Token do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec obtain(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.obtain_token_request()) ::
+  @spec obtain(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.obtain_token_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.obtain_token_response())
-  def obtain(client, path_params \\ %{}, params \\ %{}) do
+  def obtain(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.obtain_token_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.obtain_token_response/0}
@@ -13,18 +14,21 @@ defmodule SquareUp.OAUTH2.Token do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/oauth2/token"
     })
   end
 
-  @spec revoke(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.revoke_token_request()) ::
+  @spec revoke(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.revoke_token_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.revoke_token_response())
-  def revoke(client, path_params \\ %{}, params \\ %{}) do
+  def revoke(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.revoke_token_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.revoke_token_response/0}
@@ -32,8 +36,10 @@ defmodule SquareUp.OAUTH2.Token do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/oauth2/revoke"

--- a/lib/square_up/resources/v1/employee.ex
+++ b/lib/square_up/resources/v1/employee.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V1.Employee do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:employee_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.v1_employee())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{employee_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_employee/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/me/employees/{employee_id}"
     })
@@ -27,46 +27,46 @@ defmodule SquareUp.V1.Employee do
   @spec update(
           SquareUp.Client.t(),
           %{required(:employee_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.v1_employee()
+          SquareUp.TypeSpecs.v1_employee(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_employee())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{employee_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.v1_employee/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_employee/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/me/employees/{employee_id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.v1_employee()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.v1_employee(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.v1_employee())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.v1_employee/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_employee/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/me/employees"
     })

--- a/lib/square_up/resources/v1/employee.ex
+++ b/lib/square_up/resources/v1/employee.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V1.Employee do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:employee_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:employee_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.v1_employee())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{employee_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_employee/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V1.Employee do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/me/employees/{employee_id}"
@@ -24,10 +27,12 @@ defmodule SquareUp.V1.Employee do
   @spec update(
           SquareUp.Client.t(),
           %{required(:employee_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.v1_employee()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_employee())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{employee_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.v1_employee/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_employee/0}
@@ -35,18 +40,21 @@ defmodule SquareUp.V1.Employee do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/me/employees/{employee_id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.v1_employee()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.v1_employee()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.v1_employee())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.v1_employee/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_employee/0}
@@ -54,8 +62,10 @@ defmodule SquareUp.V1.Employee do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/me/employees"

--- a/lib/square_up/resources/v1/employee_role.ex
+++ b/lib/square_up/resources/v1/employee_role.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V1.EmployeeRole do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:role_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:role_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.v1_employee_role())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{role_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_employee_role/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V1.EmployeeRole do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/me/roles/{role_id}"
@@ -24,10 +27,12 @@ defmodule SquareUp.V1.EmployeeRole do
   @spec update(
           SquareUp.Client.t(),
           %{required(:role_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.v1_employee_role()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_employee_role())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{role_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.v1_employee_role/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_employee_role/0}
@@ -35,19 +40,22 @@ defmodule SquareUp.V1.EmployeeRole do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/me/roles/{role_id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, %{
+  @spec create(SquareUp.Client.t(), %{}, %{}, %{
           required(:employee_role) => SquareUp.TypeSpecs.v1_employee_role()
         }) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_employee_role())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     params_spec =
       schema(%{employee_role: Norm.Delegate.delegate(&SquareUp.NormSchema.v1_employee_role/0)})
@@ -57,8 +65,10 @@ defmodule SquareUp.V1.EmployeeRole do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/me/roles"

--- a/lib/square_up/resources/v1/employee_role.ex
+++ b/lib/square_up/resources/v1/employee_role.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V1.EmployeeRole do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:role_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.v1_employee_role())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{role_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_employee_role/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/me/roles/{role_id}"
     })
@@ -27,49 +27,53 @@ defmodule SquareUp.V1.EmployeeRole do
   @spec update(
           SquareUp.Client.t(),
           %{required(:role_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.v1_employee_role()
+          SquareUp.TypeSpecs.v1_employee_role(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_employee_role())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{role_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.v1_employee_role/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_employee_role/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/me/roles/{role_id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, %{
-          required(:employee_role) => SquareUp.TypeSpecs.v1_employee_role()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_employee_role())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec create(
+          SquareUp.Client.t(),
+          %{},
+          %{required(:employee_role) => SquareUp.TypeSpecs.v1_employee_role()},
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_employee_role())
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
 
     params_spec =
       schema(%{employee_role: Norm.Delegate.delegate(&SquareUp.NormSchema.v1_employee_role/0)})
+
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_employee_role/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/me/roles"
     })

--- a/lib/square_up/resources/v1/employee_roles.ex
+++ b/lib/square_up/resources/v1/employee_roles.ex
@@ -2,18 +2,14 @@ defmodule SquareUp.V1.EmployeeRoles do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{
-            optional(:order) => binary(),
-            optional(:limit) => integer(),
-            optional(:batch_token) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_employee_role()])
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          optional(:order) => binary(),
+          optional(:limit) => integer(),
+          optional(:batch_token) => binary()
+        }) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_employee_role()])
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -22,18 +18,16 @@ defmodule SquareUp.V1.EmployeeRoles do
         batch_token: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = [{:delegate, &SquareUp.ResponseSchema.v1_employee_role/0}]
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/me/roles"
     })

--- a/lib/square_up/resources/v1/employee_roles.ex
+++ b/lib/square_up/resources/v1/employee_roles.ex
@@ -2,28 +2,37 @@ defmodule SquareUp.V1.EmployeeRoles do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          optional(:order) => binary(),
-          optional(:limit) => integer(),
-          optional(:batch_token) => binary()
-        }) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_employee_role()])
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{
+            optional(:order) => binary(),
+            optional(:limit) => integer(),
+            optional(:batch_token) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_employee_role()])
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         order: spec(is_binary()),
         limit: spec(is_integer()),
         batch_token: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = [{:delegate, &SquareUp.ResponseSchema.v1_employee_role/0}]
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/me/roles"

--- a/lib/square_up/resources/v1/employees.ex
+++ b/lib/square_up/resources/v1/employees.ex
@@ -2,24 +2,20 @@ defmodule SquareUp.V1.Employees do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{
-            optional(:order) => binary(),
-            optional(:begin_updated_at) => binary(),
-            optional(:end_updated_at) => binary(),
-            optional(:begin_created_at) => binary(),
-            optional(:end_created_at) => binary(),
-            optional(:status) => binary(),
-            optional(:external_id) => binary(),
-            optional(:limit) => integer(),
-            optional(:batch_token) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_employee()])
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          optional(:order) => binary(),
+          optional(:begin_updated_at) => binary(),
+          optional(:end_updated_at) => binary(),
+          optional(:begin_created_at) => binary(),
+          optional(:end_created_at) => binary(),
+          optional(:status) => binary(),
+          optional(:external_id) => binary(),
+          optional(:limit) => integer(),
+          optional(:batch_token) => binary()
+        }) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_employee()])
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -34,18 +30,16 @@ defmodule SquareUp.V1.Employees do
         batch_token: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = [{:delegate, &SquareUp.ResponseSchema.v1_employee/0}]
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/me/employees"
     })

--- a/lib/square_up/resources/v1/employees.ex
+++ b/lib/square_up/resources/v1/employees.ex
@@ -2,21 +2,26 @@ defmodule SquareUp.V1.Employees do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          optional(:order) => binary(),
-          optional(:begin_updated_at) => binary(),
-          optional(:end_updated_at) => binary(),
-          optional(:begin_created_at) => binary(),
-          optional(:end_created_at) => binary(),
-          optional(:status) => binary(),
-          optional(:external_id) => binary(),
-          optional(:limit) => integer(),
-          optional(:batch_token) => binary()
-        }) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_employee()])
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{
+            optional(:order) => binary(),
+            optional(:begin_updated_at) => binary(),
+            optional(:end_updated_at) => binary(),
+            optional(:begin_created_at) => binary(),
+            optional(:end_created_at) => binary(),
+            optional(:status) => binary(),
+            optional(:external_id) => binary(),
+            optional(:limit) => integer(),
+            optional(:batch_token) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_employee()])
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         order: spec(is_binary()),
         begin_updated_at: spec(is_binary()),
@@ -29,13 +34,17 @@ defmodule SquareUp.V1.Employees do
         batch_token: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = [{:delegate, &SquareUp.ResponseSchema.v1_employee/0}]
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/me/employees"

--- a/lib/square_up/resources/v1/order.ex
+++ b/lib/square_up/resources/v1/order.ex
@@ -5,10 +5,12 @@ defmodule SquareUp.V1.Order do
   @spec retrieve(
           SquareUp.Client.t(),
           %{required(:location_id) => binary(), required(:order_id) => binary()},
+          %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_order())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary()), order_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_order/0}
@@ -16,8 +18,10 @@ defmodule SquareUp.V1.Order do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/orders/{order_id}"
@@ -27,10 +31,12 @@ defmodule SquareUp.V1.Order do
   @spec update(
           SquareUp.Client.t(),
           %{required(:location_id) => binary(), required(:order_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.v1_update_order_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_order())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary()), order_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.v1_update_order_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_order/0}
@@ -38,8 +44,10 @@ defmodule SquareUp.V1.Order do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/orders/{order_id}"

--- a/lib/square_up/resources/v1/order.ex
+++ b/lib/square_up/resources/v1/order.ex
@@ -8,21 +8,21 @@ defmodule SquareUp.V1.Order do
           %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_order())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary()), order_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_order/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/orders/{order_id}"
     })
@@ -31,24 +31,24 @@ defmodule SquareUp.V1.Order do
   @spec update(
           SquareUp.Client.t(),
           %{required(:location_id) => binary(), required(:order_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.v1_update_order_request()
+          SquareUp.TypeSpecs.v1_update_order_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_order())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary()), order_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.v1_update_order_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_order/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/orders/{order_id}"
     })

--- a/lib/square_up/resources/v1/orders.ex
+++ b/lib/square_up/resources/v1/orders.ex
@@ -2,18 +2,14 @@ defmodule SquareUp.V1.Orders do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{required(:location_id) => binary()},
-          %{
-            optional(:order) => binary(),
-            optional(:limit) => integer(),
-            optional(:batch_token) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_order()])
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{required(:location_id) => binary()}, %{}, %{
+          optional(:order) => binary(),
+          optional(:limit) => integer(),
+          optional(:batch_token) => binary()
+        }) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_order()])
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -22,18 +18,16 @@ defmodule SquareUp.V1.Orders do
         batch_token: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = [{:delegate, &SquareUp.ResponseSchema.v1_order/0}]
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/orders"
     })

--- a/lib/square_up/resources/v1/orders.ex
+++ b/lib/square_up/resources/v1/orders.ex
@@ -2,28 +2,37 @@ defmodule SquareUp.V1.Orders do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{required(:location_id) => binary()}, %{
-          optional(:order) => binary(),
-          optional(:limit) => integer(),
-          optional(:batch_token) => binary()
-        }) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_order()])
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{required(:location_id) => binary()},
+          %{
+            optional(:order) => binary(),
+            optional(:limit) => integer(),
+            optional(:batch_token) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_order()])
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         order: spec(is_binary()),
         limit: spec(is_integer()),
         batch_token: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = [{:delegate, &SquareUp.ResponseSchema.v1_order/0}]
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/orders"

--- a/lib/square_up/resources/v1/payment.ex
+++ b/lib/square_up/resources/v1/payment.ex
@@ -8,21 +8,21 @@ defmodule SquareUp.V1.Payment do
           %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_payment())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary()), payment_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_payment/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/payments/{payment_id}"
     })

--- a/lib/square_up/resources/v1/payment.ex
+++ b/lib/square_up/resources/v1/payment.ex
@@ -5,10 +5,12 @@ defmodule SquareUp.V1.Payment do
   @spec retrieve(
           SquareUp.Client.t(),
           %{required(:location_id) => binary(), required(:payment_id) => binary()},
+          %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_payment())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary()), payment_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_payment/0}
@@ -16,8 +18,10 @@ defmodule SquareUp.V1.Payment do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/payments/{payment_id}"

--- a/lib/square_up/resources/v1/payments.ex
+++ b/lib/square_up/resources/v1/payments.ex
@@ -2,18 +2,23 @@ defmodule SquareUp.V1.Payments do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{required(:location_id) => binary()}, %{
-          optional(:order) => binary(),
-          optional(:begin_time) => binary(),
-          optional(:end_time) => binary(),
-          optional(:limit) => integer(),
-          optional(:batch_token) => binary(),
-          optional(:include_partial) => boolean()
-        }) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_payment()])
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{required(:location_id) => binary()},
+          %{
+            optional(:order) => binary(),
+            optional(:begin_time) => binary(),
+            optional(:end_time) => binary(),
+            optional(:limit) => integer(),
+            optional(:batch_token) => binary(),
+            optional(:include_partial) => boolean()
+          },
+          %{}
+        ) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_payment()])
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         order: spec(is_binary()),
         begin_time: spec(is_binary()),
@@ -23,13 +28,17 @@ defmodule SquareUp.V1.Payments do
         include_partial: spec(is_boolean())
       })
 
+    params_spec = schema(%{})
+
     response_spec = [{:delegate, &SquareUp.ResponseSchema.v1_payment/0}]
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/payments"

--- a/lib/square_up/resources/v1/payments.ex
+++ b/lib/square_up/resources/v1/payments.ex
@@ -2,21 +2,17 @@ defmodule SquareUp.V1.Payments do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{required(:location_id) => binary()},
-          %{
-            optional(:order) => binary(),
-            optional(:begin_time) => binary(),
-            optional(:end_time) => binary(),
-            optional(:limit) => integer(),
-            optional(:batch_token) => binary(),
-            optional(:include_partial) => boolean()
-          },
-          %{}
-        ) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_payment()])
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{required(:location_id) => binary()}, %{}, %{
+          optional(:order) => binary(),
+          optional(:begin_time) => binary(),
+          optional(:end_time) => binary(),
+          optional(:limit) => integer(),
+          optional(:batch_token) => binary(),
+          optional(:include_partial) => boolean()
+        }) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_payment()])
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -28,18 +24,16 @@ defmodule SquareUp.V1.Payments do
         include_partial: spec(is_boolean())
       })
 
-    params_spec = schema(%{})
-
     response_spec = [{:delegate, &SquareUp.ResponseSchema.v1_payment/0}]
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/payments"
     })

--- a/lib/square_up/resources/v1/refund.ex
+++ b/lib/square_up/resources/v1/refund.ex
@@ -5,10 +5,12 @@ defmodule SquareUp.V1.Refund do
   @spec create(
           SquareUp.Client.t(),
           %{required(:location_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.v1_create_refund_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_refund())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.v1_create_refund_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_refund/0}
@@ -16,8 +18,10 @@ defmodule SquareUp.V1.Refund do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/refunds"

--- a/lib/square_up/resources/v1/refund.ex
+++ b/lib/square_up/resources/v1/refund.ex
@@ -5,24 +5,24 @@ defmodule SquareUp.V1.Refund do
   @spec create(
           SquareUp.Client.t(),
           %{required(:location_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.v1_create_refund_request()
+          SquareUp.TypeSpecs.v1_create_refund_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_refund())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.v1_create_refund_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_refund/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/refunds"
     })

--- a/lib/square_up/resources/v1/refunds.ex
+++ b/lib/square_up/resources/v1/refunds.ex
@@ -2,20 +2,16 @@ defmodule SquareUp.V1.Refunds do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{required(:location_id) => binary()},
-          %{
-            optional(:order) => binary(),
-            optional(:begin_time) => binary(),
-            optional(:end_time) => binary(),
-            optional(:limit) => integer(),
-            optional(:batch_token) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_refund()])
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{required(:location_id) => binary()}, %{}, %{
+          optional(:order) => binary(),
+          optional(:begin_time) => binary(),
+          optional(:end_time) => binary(),
+          optional(:limit) => integer(),
+          optional(:batch_token) => binary()
+        }) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_refund()])
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -26,18 +22,16 @@ defmodule SquareUp.V1.Refunds do
         batch_token: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = [{:delegate, &SquareUp.ResponseSchema.v1_refund/0}]
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/refunds"
     })

--- a/lib/square_up/resources/v1/refunds.ex
+++ b/lib/square_up/resources/v1/refunds.ex
@@ -2,17 +2,22 @@ defmodule SquareUp.V1.Refunds do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{required(:location_id) => binary()}, %{
-          optional(:order) => binary(),
-          optional(:begin_time) => binary(),
-          optional(:end_time) => binary(),
-          optional(:limit) => integer(),
-          optional(:batch_token) => binary()
-        }) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_refund()])
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{required(:location_id) => binary()},
+          %{
+            optional(:order) => binary(),
+            optional(:begin_time) => binary(),
+            optional(:end_time) => binary(),
+            optional(:limit) => integer(),
+            optional(:batch_token) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_refund()])
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         order: spec(is_binary()),
         begin_time: spec(is_binary()),
@@ -21,13 +26,17 @@ defmodule SquareUp.V1.Refunds do
         batch_token: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = [{:delegate, &SquareUp.ResponseSchema.v1_refund/0}]
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/refunds"

--- a/lib/square_up/resources/v1/settlement.ex
+++ b/lib/square_up/resources/v1/settlement.ex
@@ -8,21 +8,21 @@ defmodule SquareUp.V1.Settlement do
           %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_settlement())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary()), settlement_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_settlement/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/settlements/{settlement_id}"
     })

--- a/lib/square_up/resources/v1/settlement.ex
+++ b/lib/square_up/resources/v1/settlement.ex
@@ -5,10 +5,12 @@ defmodule SquareUp.V1.Settlement do
   @spec retrieve(
           SquareUp.Client.t(),
           %{required(:location_id) => binary(), required(:settlement_id) => binary()},
+          %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.v1_settlement())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary()), settlement_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.v1_settlement/0}
@@ -16,8 +18,10 @@ defmodule SquareUp.V1.Settlement do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/settlements/{settlement_id}"

--- a/lib/square_up/resources/v1/settlements.ex
+++ b/lib/square_up/resources/v1/settlements.ex
@@ -2,21 +2,17 @@ defmodule SquareUp.V1.Settlements do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{required(:location_id) => binary()},
-          %{
-            optional(:order) => binary(),
-            optional(:begin_time) => binary(),
-            optional(:end_time) => binary(),
-            optional(:limit) => integer(),
-            optional(:status) => binary(),
-            optional(:batch_token) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_settlement()])
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{required(:location_id) => binary()}, %{}, %{
+          optional(:order) => binary(),
+          optional(:begin_time) => binary(),
+          optional(:end_time) => binary(),
+          optional(:limit) => integer(),
+          optional(:status) => binary(),
+          optional(:batch_token) => binary()
+        }) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_settlement()])
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -28,18 +24,16 @@ defmodule SquareUp.V1.Settlements do
         batch_token: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = [{:delegate, &SquareUp.ResponseSchema.v1_settlement/0}]
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/settlements"
     })

--- a/lib/square_up/resources/v1/settlements.ex
+++ b/lib/square_up/resources/v1/settlements.ex
@@ -2,18 +2,23 @@ defmodule SquareUp.V1.Settlements do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{required(:location_id) => binary()}, %{
-          optional(:order) => binary(),
-          optional(:begin_time) => binary(),
-          optional(:end_time) => binary(),
-          optional(:limit) => integer(),
-          optional(:status) => binary(),
-          optional(:batch_token) => binary()
-        }) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_settlement()])
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{required(:location_id) => binary()},
+          %{
+            optional(:order) => binary(),
+            optional(:begin_time) => binary(),
+            optional(:end_time) => binary(),
+            optional(:limit) => integer(),
+            optional(:status) => binary(),
+            optional(:batch_token) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response([SquareUp.TypeSpecs.v1_settlement()])
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         order: spec(is_binary()),
         begin_time: spec(is_binary()),
@@ -23,13 +28,17 @@ defmodule SquareUp.V1.Settlements do
         batch_token: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = [{:delegate, &SquareUp.ResponseSchema.v1_settlement/0}]
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v1/{location_id}/settlements"

--- a/lib/square_up/resources/v2/bank_account.ex
+++ b/lib/square_up/resources/v2/bank_account.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.BankAccount do
 
   @spec get(SquareUp.Client.t(), %{required(:bank_account_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_bank_account_response())
-  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{bank_account_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_bank_account_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/bank-accounts/{bank_account_id}"
     })

--- a/lib/square_up/resources/v2/bank_account.ex
+++ b/lib/square_up/resources/v2/bank_account.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.BankAccount do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec get(SquareUp.Client.t(), %{required(:bank_account_id) => binary()}, %{}) ::
+  @spec get(SquareUp.Client.t(), %{required(:bank_account_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_bank_account_response())
-  def get(client, path_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{bank_account_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_bank_account_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.BankAccount do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/bank-accounts/{bank_account_id}"

--- a/lib/square_up/resources/v2/bank_account_by_v1_id.ex
+++ b/lib/square_up/resources/v2/bank_account_by_v1_id.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.BankAccountByV1Id do
 
   @spec get(SquareUp.Client.t(), %{required(:v1_bank_account_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_bank_account_by_v1_id_response())
-  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{v1_bank_account_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_bank_account_by_v1_id_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/bank-accounts/by-v1-id/{v1_bank_account_id}"
     })

--- a/lib/square_up/resources/v2/bank_account_by_v1_id.ex
+++ b/lib/square_up/resources/v2/bank_account_by_v1_id.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.BankAccountByV1Id do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec get(SquareUp.Client.t(), %{required(:v1_bank_account_id) => binary()}, %{}) ::
+  @spec get(SquareUp.Client.t(), %{required(:v1_bank_account_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_bank_account_by_v1_id_response())
-  def get(client, path_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{v1_bank_account_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_bank_account_by_v1_id_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.BankAccountByV1Id do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/bank-accounts/by-v1-id/{v1_bank_account_id}"

--- a/lib/square_up/resources/v2/bank_accounts.ex
+++ b/lib/square_up/resources/v2/bank_accounts.ex
@@ -2,18 +2,14 @@ defmodule SquareUp.V2.BankAccounts do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{
-            optional(:cursor) => binary(),
-            optional(:limit) => integer(),
-            optional(:location_id) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_bank_accounts_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          optional(:cursor) => binary(),
+          optional(:limit) => integer(),
+          optional(:location_id) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_bank_accounts_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -22,18 +18,16 @@ defmodule SquareUp.V2.BankAccounts do
         location_id: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_bank_accounts_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/bank-accounts"
     })

--- a/lib/square_up/resources/v2/bank_accounts.ex
+++ b/lib/square_up/resources/v2/bank_accounts.ex
@@ -2,28 +2,37 @@ defmodule SquareUp.V2.BankAccounts do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          optional(:cursor) => binary(),
-          optional(:limit) => integer(),
-          optional(:location_id) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_bank_accounts_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{
+            optional(:cursor) => binary(),
+            optional(:limit) => integer(),
+            optional(:location_id) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_bank_accounts_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         cursor: spec(is_binary()),
         limit: spec(is_integer()),
         location_id: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_bank_accounts_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/bank-accounts"

--- a/lib/square_up/resources/v2/break_type.ex
+++ b/lib/square_up/resources/v2/break_type.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.BreakType do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec delete(SquareUp.Client.t(), %{required(:id) => binary()}, %{}) ::
+  @spec delete(SquareUp.Client.t(), %{required(:id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.delete_break_type_response())
-  def delete(client, path_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_break_type_response/0}
@@ -13,18 +14,21 @@ defmodule SquareUp.V2.BreakType do
     call(client, %{
       method: :delete,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/break-types/{id}"
     })
   end
 
-  @spec get(SquareUp.Client.t(), %{required(:id) => binary()}, %{}) ::
+  @spec get(SquareUp.Client.t(), %{required(:id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_break_type_response())
-  def get(client, path_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_break_type_response/0}
@@ -32,8 +36,10 @@ defmodule SquareUp.V2.BreakType do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/break-types/{id}"
@@ -43,10 +49,12 @@ defmodule SquareUp.V2.BreakType do
   @spec update(
           SquareUp.Client.t(),
           %{required(:id) => binary()},
+          %{},
           SquareUp.TypeSpecs.update_break_type_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_break_type_response())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_break_type_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_break_type_response/0}
@@ -54,18 +62,21 @@ defmodule SquareUp.V2.BreakType do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/break-types/{id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_break_type_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_break_type_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_break_type_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_break_type_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_break_type_response/0}
@@ -73,8 +84,10 @@ defmodule SquareUp.V2.BreakType do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/break-types"

--- a/lib/square_up/resources/v2/break_type.ex
+++ b/lib/square_up/resources/v2/break_type.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.BreakType do
 
   @spec delete(SquareUp.Client.t(), %{required(:id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.delete_break_type_response())
-  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_break_type_response/0}
 
     call(client, %{
       method: :delete,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/break-types/{id}"
     })
@@ -26,21 +26,21 @@ defmodule SquareUp.V2.BreakType do
 
   @spec get(SquareUp.Client.t(), %{required(:id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_break_type_response())
-  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_break_type_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/break-types/{id}"
     })
@@ -49,46 +49,46 @@ defmodule SquareUp.V2.BreakType do
   @spec update(
           SquareUp.Client.t(),
           %{required(:id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.update_break_type_request()
+          SquareUp.TypeSpecs.update_break_type_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_break_type_response())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_break_type_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_break_type_response/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/break-types/{id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_break_type_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_break_type_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_break_type_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_break_type_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_break_type_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/break-types"
     })

--- a/lib/square_up/resources/v2/break_types.ex
+++ b/lib/square_up/resources/v2/break_types.ex
@@ -2,18 +2,14 @@ defmodule SquareUp.V2.BreakTypes do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{
-            optional(:location_id) => binary(),
-            optional(:limit) => integer(),
-            optional(:cursor) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_break_types_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          optional(:location_id) => binary(),
+          optional(:limit) => integer(),
+          optional(:cursor) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_break_types_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -22,18 +18,16 @@ defmodule SquareUp.V2.BreakTypes do
         cursor: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_break_types_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/break-types"
     })

--- a/lib/square_up/resources/v2/break_types.ex
+++ b/lib/square_up/resources/v2/break_types.ex
@@ -2,28 +2,37 @@ defmodule SquareUp.V2.BreakTypes do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          optional(:location_id) => binary(),
-          optional(:limit) => integer(),
-          optional(:cursor) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_break_types_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{
+            optional(:location_id) => binary(),
+            optional(:limit) => integer(),
+            optional(:cursor) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_break_types_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         location_id: spec(is_binary()),
         limit: spec(is_integer()),
         cursor: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_break_types_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/break-types"

--- a/lib/square_up/resources/v2/cash_drawer_shift.ex
+++ b/lib/square_up/resources/v2/cash_drawer_shift.ex
@@ -2,20 +2,26 @@ defmodule SquareUp.V2.CashDrawerShift do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:shift_id) => binary()}, %{
-          required(:location_id) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_cash_drawer_shift_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  @spec retrieve(
+          SquareUp.Client.t(),
+          %{required(:shift_id) => binary()},
+          %{required(:location_id) => binary()},
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_cash_drawer_shift_response())
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{shift_id: spec(is_binary())})
-    params_spec = schema(%{location_id: spec(is_binary())})
+    query_params_spec = schema(%{location_id: spec(is_binary())})
+    params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_cash_drawer_shift_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/cash-drawers/shifts/{shift_id}"

--- a/lib/square_up/resources/v2/cash_drawer_shift.ex
+++ b/lib/square_up/resources/v2/cash_drawer_shift.ex
@@ -2,27 +2,24 @@ defmodule SquareUp.V2.CashDrawerShift do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(
-          SquareUp.Client.t(),
-          %{required(:shift_id) => binary()},
-          %{required(:location_id) => binary()},
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_cash_drawer_shift_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec retrieve(SquareUp.Client.t(), %{required(:shift_id) => binary()}, %{}, %{
+          required(:location_id) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_cash_drawer_shift_response())
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{shift_id: spec(is_binary())})
-    query_params_spec = schema(%{location_id: spec(is_binary())})
     params_spec = schema(%{})
+    query_params_spec = schema(%{location_id: spec(is_binary())})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_cash_drawer_shift_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/cash-drawers/shifts/{shift_id}"
     })

--- a/lib/square_up/resources/v2/cash_drawer_shift_events.ex
+++ b/lib/square_up/resources/v2/cash_drawer_shift_events.ex
@@ -2,29 +2,37 @@ defmodule SquareUp.V2.CashDrawerShiftEvents do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{required(:shift_id) => binary()}, %{
-          required(:location_id) => binary(),
-          optional(:limit) => integer(),
-          optional(:cursor) => binary()
-        }) ::
-          SquareUp.Client.response(SquareUp.TypeSpecs.list_cash_drawer_shift_events_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{required(:shift_id) => binary()},
+          %{
+            required(:location_id) => binary(),
+            optional(:limit) => integer(),
+            optional(:cursor) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_cash_drawer_shift_events_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{shift_id: spec(is_binary())})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         location_id: spec(is_binary()),
         limit: spec(is_integer()),
         cursor: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_cash_drawer_shift_events_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/cash-drawers/shifts/{shift_id}/events"

--- a/lib/square_up/resources/v2/cash_drawer_shift_events.ex
+++ b/lib/square_up/resources/v2/cash_drawer_shift_events.ex
@@ -2,18 +2,15 @@ defmodule SquareUp.V2.CashDrawerShiftEvents do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{required(:shift_id) => binary()},
-          %{
-            required(:location_id) => binary(),
-            optional(:limit) => integer(),
-            optional(:cursor) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_cash_drawer_shift_events_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{required(:shift_id) => binary()}, %{}, %{
+          required(:location_id) => binary(),
+          optional(:limit) => integer(),
+          optional(:cursor) => binary()
+        }) ::
+          SquareUp.Client.response(SquareUp.TypeSpecs.list_cash_drawer_shift_events_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{shift_id: spec(is_binary())})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -22,18 +19,16 @@ defmodule SquareUp.V2.CashDrawerShiftEvents do
         cursor: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_cash_drawer_shift_events_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/cash-drawers/shifts/{shift_id}/events"
     })

--- a/lib/square_up/resources/v2/cash_drawer_shifts.ex
+++ b/lib/square_up/resources/v2/cash_drawer_shifts.ex
@@ -2,18 +2,23 @@ defmodule SquareUp.V2.CashDrawerShifts do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          required(:location_id) => binary(),
-          optional(:sort_order) => binary(),
-          optional(:begin_time) => binary(),
-          optional(:end_time) => binary(),
-          optional(:limit) => integer(),
-          optional(:cursor) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_cash_drawer_shifts_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{
+            required(:location_id) => binary(),
+            optional(:sort_order) => binary(),
+            optional(:begin_time) => binary(),
+            optional(:end_time) => binary(),
+            optional(:limit) => integer(),
+            optional(:cursor) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_cash_drawer_shifts_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         location_id: spec(is_binary()),
         sort_order: spec(is_binary()),
@@ -23,13 +28,17 @@ defmodule SquareUp.V2.CashDrawerShifts do
         cursor: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_cash_drawer_shifts_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/cash-drawers/shifts"

--- a/lib/square_up/resources/v2/cash_drawer_shifts.ex
+++ b/lib/square_up/resources/v2/cash_drawer_shifts.ex
@@ -2,21 +2,17 @@ defmodule SquareUp.V2.CashDrawerShifts do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{
-            required(:location_id) => binary(),
-            optional(:sort_order) => binary(),
-            optional(:begin_time) => binary(),
-            optional(:end_time) => binary(),
-            optional(:limit) => integer(),
-            optional(:cursor) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_cash_drawer_shifts_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          required(:location_id) => binary(),
+          optional(:sort_order) => binary(),
+          optional(:begin_time) => binary(),
+          optional(:end_time) => binary(),
+          optional(:limit) => integer(),
+          optional(:cursor) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_cash_drawer_shifts_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -28,18 +24,16 @@ defmodule SquareUp.V2.CashDrawerShifts do
         cursor: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_cash_drawer_shifts_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/cash-drawers/shifts"
     })

--- a/lib/square_up/resources/v2/catalog.ex
+++ b/lib/square_up/resources/v2/catalog.ex
@@ -2,21 +2,26 @@ defmodule SquareUp.V2.Catalog do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          optional(:cursor) => binary(),
-          optional(:types) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_catalog_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{optional(:cursor) => binary(), optional(:types) => binary()},
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_catalog_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
-    params_spec = schema(%{cursor: spec(is_binary()), types: spec(is_binary())})
+    query_params_spec = schema(%{cursor: spec(is_binary()), types: spec(is_binary())})
+    params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_catalog_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/list"

--- a/lib/square_up/resources/v2/catalog.ex
+++ b/lib/square_up/resources/v2/catalog.ex
@@ -2,27 +2,25 @@ defmodule SquareUp.V2.Catalog do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{optional(:cursor) => binary(), optional(:types) => binary()},
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_catalog_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          optional(:cursor) => binary(),
+          optional(:types) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_catalog_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{cursor: spec(is_binary()), types: spec(is_binary())})
     params_spec = schema(%{})
+    query_params_spec = schema(%{cursor: spec(is_binary()), types: spec(is_binary())})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_catalog_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/list"
     })

--- a/lib/square_up/resources/v2/catalog_items.ex
+++ b/lib/square_up/resources/v2/catalog_items.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.CatalogItems do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_catalog_items_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_catalog_items_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_catalog_items_response())
-  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_catalog_items_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_catalog_items_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/search-catalog-items"
     })

--- a/lib/square_up/resources/v2/catalog_items.ex
+++ b/lib/square_up/resources/v2/catalog_items.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.CatalogItems do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_catalog_items_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_catalog_items_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_catalog_items_response())
-  def search(client, path_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_catalog_items_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_catalog_items_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.CatalogItems do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/search-catalog-items"

--- a/lib/square_up/resources/v2/catalog_object.ex
+++ b/lib/square_up/resources/v2/catalog_object.ex
@@ -4,69 +4,66 @@ defmodule SquareUp.V2.CatalogObject do
 
   @spec delete(SquareUp.Client.t(), %{required(:object_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.delete_catalog_object_response())
-  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{object_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_catalog_object_response/0}
 
     call(client, %{
       method: :delete,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/object/{object_id}"
     })
   end
 
-  @spec retrieve(
-          SquareUp.Client.t(),
-          %{required(:object_id) => binary()},
-          %{optional(:include_related_objects) => boolean()},
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_catalog_object_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec retrieve(SquareUp.Client.t(), %{required(:object_id) => binary()}, %{}, %{
+          optional(:include_related_objects) => boolean()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_catalog_object_response())
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{object_id: spec(is_binary())})
-    query_params_spec = schema(%{include_related_objects: spec(is_boolean())})
     params_spec = schema(%{})
+    query_params_spec = schema(%{include_related_objects: spec(is_boolean())})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_catalog_object_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/object/{object_id}"
     })
   end
 
-  @spec upsert(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.upsert_catalog_object_request()) ::
+  @spec upsert(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.upsert_catalog_object_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.upsert_catalog_object_response())
-  def upsert(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def upsert(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.upsert_catalog_object_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.upsert_catalog_object_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/object"
     })

--- a/lib/square_up/resources/v2/catalog_object.ex
+++ b/lib/square_up/resources/v2/catalog_object.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.CatalogObject do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec delete(SquareUp.Client.t(), %{required(:object_id) => binary()}, %{}) ::
+  @spec delete(SquareUp.Client.t(), %{required(:object_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.delete_catalog_object_response())
-  def delete(client, path_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{object_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_catalog_object_response/0}
@@ -13,38 +14,47 @@ defmodule SquareUp.V2.CatalogObject do
     call(client, %{
       method: :delete,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/object/{object_id}"
     })
   end
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:object_id) => binary()}, %{
-          optional(:include_related_objects) => boolean()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_catalog_object_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  @spec retrieve(
+          SquareUp.Client.t(),
+          %{required(:object_id) => binary()},
+          %{optional(:include_related_objects) => boolean()},
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_catalog_object_response())
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{object_id: spec(is_binary())})
-    params_spec = schema(%{include_related_objects: spec(is_boolean())})
+    query_params_spec = schema(%{include_related_objects: spec(is_boolean())})
+    params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_catalog_object_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/object/{object_id}"
     })
   end
 
-  @spec upsert(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.upsert_catalog_object_request()) ::
+  @spec upsert(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.upsert_catalog_object_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.upsert_catalog_object_response())
-  def upsert(client, path_params \\ %{}, params \\ %{}) do
+  def upsert(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.upsert_catalog_object_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.upsert_catalog_object_response/0}
@@ -52,8 +62,10 @@ defmodule SquareUp.V2.CatalogObject do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/object"

--- a/lib/square_up/resources/v2/catalog_objects.ex
+++ b/lib/square_up/resources/v2/catalog_objects.ex
@@ -5,10 +5,12 @@ defmodule SquareUp.V2.CatalogObjects do
   @spec batch_delete(
           SquareUp.Client.t(),
           %{},
+          %{},
           SquareUp.TypeSpecs.batch_delete_catalog_objects_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.batch_delete_catalog_objects_response())
-  def batch_delete(client, path_params \\ %{}, params \\ %{}) do
+  def batch_delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.batch_delete_catalog_objects_request/0)
@@ -18,8 +20,10 @@ defmodule SquareUp.V2.CatalogObjects do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/batch-delete"
@@ -29,11 +33,13 @@ defmodule SquareUp.V2.CatalogObjects do
   @spec batch_retrieve(
           SquareUp.Client.t(),
           %{},
+          %{},
           SquareUp.TypeSpecs.batch_retrieve_catalog_objects_request()
         ) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.batch_retrieve_catalog_objects_response())
-  def batch_retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def batch_retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.batch_retrieve_catalog_objects_request/0)
@@ -44,18 +50,21 @@ defmodule SquareUp.V2.CatalogObjects do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/batch-retrieve"
     })
   end
 
-  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_catalog_objects_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_catalog_objects_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_catalog_objects_response())
-  def search(client, path_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_catalog_objects_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_catalog_objects_response/0}
@@ -63,8 +72,10 @@ defmodule SquareUp.V2.CatalogObjects do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/search"

--- a/lib/square_up/resources/v2/catalog_objects.ex
+++ b/lib/square_up/resources/v2/catalog_objects.ex
@@ -5,26 +5,27 @@ defmodule SquareUp.V2.CatalogObjects do
   @spec batch_delete(
           SquareUp.Client.t(),
           %{},
-          %{},
-          SquareUp.TypeSpecs.batch_delete_catalog_objects_request()
+          SquareUp.TypeSpecs.batch_delete_catalog_objects_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.batch_delete_catalog_objects_response())
-  def batch_delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def batch_delete(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.batch_delete_catalog_objects_request/0)
+
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.batch_delete_catalog_objects_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/batch-delete"
     })
@@ -33,16 +34,17 @@ defmodule SquareUp.V2.CatalogObjects do
   @spec batch_retrieve(
           SquareUp.Client.t(),
           %{},
-          %{},
-          SquareUp.TypeSpecs.batch_retrieve_catalog_objects_request()
+          SquareUp.TypeSpecs.batch_retrieve_catalog_objects_request(),
+          %{}
         ) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.batch_retrieve_catalog_objects_response())
-  def batch_retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def batch_retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.batch_retrieve_catalog_objects_request/0)
+
+    query_params_spec = schema(%{})
 
     response_spec =
       {:delegate, &SquareUp.ResponseSchema.batch_retrieve_catalog_objects_response/0}
@@ -50,33 +52,33 @@ defmodule SquareUp.V2.CatalogObjects do
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/batch-retrieve"
     })
   end
 
-  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_catalog_objects_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_catalog_objects_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_catalog_objects_response())
-  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_catalog_objects_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_catalog_objects_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/search"
     })

--- a/lib/square_up/resources/v2/change_inventory.ex
+++ b/lib/square_up/resources/v2/change_inventory.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.ChangeInventory do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec batch(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.batch_change_inventory_request()) ::
+  @spec batch(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.batch_change_inventory_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.batch_change_inventory_response())
-  def batch(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def batch(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.batch_change_inventory_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.batch_change_inventory_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/batch-change"
     })

--- a/lib/square_up/resources/v2/change_inventory.ex
+++ b/lib/square_up/resources/v2/change_inventory.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.ChangeInventory do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec batch(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.batch_change_inventory_request()) ::
+  @spec batch(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.batch_change_inventory_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.batch_change_inventory_response())
-  def batch(client, path_params \\ %{}, params \\ %{}) do
+  def batch(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.batch_change_inventory_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.batch_change_inventory_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.ChangeInventory do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/batch-change"

--- a/lib/square_up/resources/v2/checkout.ex
+++ b/lib/square_up/resources/v2/checkout.ex
@@ -5,10 +5,12 @@ defmodule SquareUp.V2.Checkout do
   @spec create(
           SquareUp.Client.t(),
           %{required(:location_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.create_checkout_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.create_checkout_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_checkout_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_checkout_response/0}
@@ -16,8 +18,10 @@ defmodule SquareUp.V2.Checkout do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/locations/{location_id}/checkouts"

--- a/lib/square_up/resources/v2/checkout.ex
+++ b/lib/square_up/resources/v2/checkout.ex
@@ -5,24 +5,24 @@ defmodule SquareUp.V2.Checkout do
   @spec create(
           SquareUp.Client.t(),
           %{required(:location_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.create_checkout_request()
+          SquareUp.TypeSpecs.create_checkout_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.create_checkout_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_checkout_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_checkout_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/locations/{location_id}/checkouts"
     })

--- a/lib/square_up/resources/v2/create_team_members.ex
+++ b/lib/square_up/resources/v2/create_team_members.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.CreateTeamMembers do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec bulk(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.bulk_create_team_members_request()) ::
+  @spec bulk(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.bulk_create_team_members_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.bulk_create_team_members_response())
-  def bulk(client, path_params \\ %{}, params \\ %{}) do
+  def bulk(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.bulk_create_team_members_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.bulk_create_team_members_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.CreateTeamMembers do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/bulk-create"

--- a/lib/square_up/resources/v2/create_team_members.ex
+++ b/lib/square_up/resources/v2/create_team_members.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.CreateTeamMembers do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec bulk(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.bulk_create_team_members_request()) ::
+  @spec bulk(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.bulk_create_team_members_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.bulk_create_team_members_response())
-  def bulk(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def bulk(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.bulk_create_team_members_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.bulk_create_team_members_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/bulk-create"
     })

--- a/lib/square_up/resources/v2/customer.ex
+++ b/lib/square_up/resources/v2/customer.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Customer do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_customer_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_customer_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_customer_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_customer_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_customer_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.Customer do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers"
@@ -24,10 +27,12 @@ defmodule SquareUp.V2.Customer do
   @spec remove_group(
           SquareUp.Client.t(),
           %{required(:customer_id) => binary(), required(:group_id) => binary()},
+          %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.remove_group_from_customer_response())
-  def remove_group(client, path_params \\ %{}, params \\ %{}) do
+  def remove_group(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary()), group_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.remove_group_from_customer_response/0}
@@ -35,8 +40,10 @@ defmodule SquareUp.V2.Customer do
     call(client, %{
       method: :delete,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}/groups/{group_id}"
@@ -46,10 +53,12 @@ defmodule SquareUp.V2.Customer do
   @spec add_group(
           SquareUp.Client.t(),
           %{required(:customer_id) => binary(), required(:group_id) => binary()},
+          %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.add_group_to_customer_response())
-  def add_group(client, path_params \\ %{}, params \\ %{}) do
+  def add_group(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary()), group_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.add_group_to_customer_response/0}
@@ -57,18 +66,21 @@ defmodule SquareUp.V2.Customer do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}/groups/{group_id}"
     })
   end
 
-  @spec delete(SquareUp.Client.t(), %{required(:customer_id) => binary()}, %{}) ::
+  @spec delete(SquareUp.Client.t(), %{required(:customer_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.delete_customer_response())
-  def delete(client, path_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_customer_response/0}
@@ -76,18 +88,21 @@ defmodule SquareUp.V2.Customer do
     call(client, %{
       method: :delete,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}"
     })
   end
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:customer_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:customer_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_customer_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_customer_response/0}
@@ -95,8 +110,10 @@ defmodule SquareUp.V2.Customer do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}"
@@ -106,10 +123,12 @@ defmodule SquareUp.V2.Customer do
   @spec update(
           SquareUp.Client.t(),
           %{required(:customer_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.update_customer_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_customer_response())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_customer_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_customer_response/0}
@@ -117,8 +136,10 @@ defmodule SquareUp.V2.Customer do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}"

--- a/lib/square_up/resources/v2/customer.ex
+++ b/lib/square_up/resources/v2/customer.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.Customer do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_customer_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_customer_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_customer_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_customer_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_customer_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers"
     })
@@ -30,21 +30,21 @@ defmodule SquareUp.V2.Customer do
           %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.remove_group_from_customer_response())
-  def remove_group(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def remove_group(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary()), group_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.remove_group_from_customer_response/0}
 
     call(client, %{
       method: :delete,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}/groups/{group_id}"
     })
@@ -56,21 +56,21 @@ defmodule SquareUp.V2.Customer do
           %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.add_group_to_customer_response())
-  def add_group(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def add_group(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary()), group_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.add_group_to_customer_response/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}/groups/{group_id}"
     })
@@ -78,21 +78,21 @@ defmodule SquareUp.V2.Customer do
 
   @spec delete(SquareUp.Client.t(), %{required(:customer_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.delete_customer_response())
-  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_customer_response/0}
 
     call(client, %{
       method: :delete,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}"
     })
@@ -100,21 +100,21 @@ defmodule SquareUp.V2.Customer do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:customer_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_customer_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_customer_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}"
     })
@@ -123,24 +123,24 @@ defmodule SquareUp.V2.Customer do
   @spec update(
           SquareUp.Client.t(),
           %{required(:customer_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.update_customer_request()
+          SquareUp.TypeSpecs.update_customer_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_customer_response())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_customer_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_customer_response/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}"
     })

--- a/lib/square_up/resources/v2/customer_card.ex
+++ b/lib/square_up/resources/v2/customer_card.ex
@@ -8,21 +8,21 @@ defmodule SquareUp.V2.CustomerCard do
           %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.delete_customer_card_response())
-  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary()), card_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_customer_card_response/0}
 
     call(client, %{
       method: :delete,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}/cards/{card_id}"
     })
@@ -31,24 +31,24 @@ defmodule SquareUp.V2.CustomerCard do
   @spec create(
           SquareUp.Client.t(),
           %{required(:customer_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.create_customer_card_request()
+          SquareUp.TypeSpecs.create_customer_card_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.create_customer_card_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_customer_card_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_customer_card_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}/cards"
     })

--- a/lib/square_up/resources/v2/customer_card.ex
+++ b/lib/square_up/resources/v2/customer_card.ex
@@ -5,10 +5,12 @@ defmodule SquareUp.V2.CustomerCard do
   @spec delete(
           SquareUp.Client.t(),
           %{required(:customer_id) => binary(), required(:card_id) => binary()},
+          %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.delete_customer_card_response())
-  def delete(client, path_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary()), card_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_customer_card_response/0}
@@ -16,8 +18,10 @@ defmodule SquareUp.V2.CustomerCard do
     call(client, %{
       method: :delete,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}/cards/{card_id}"
@@ -27,10 +31,12 @@ defmodule SquareUp.V2.CustomerCard do
   @spec create(
           SquareUp.Client.t(),
           %{required(:customer_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.create_customer_card_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.create_customer_card_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{customer_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_customer_card_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_customer_card_response/0}
@@ -38,8 +44,10 @@ defmodule SquareUp.V2.CustomerCard do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/{customer_id}/cards"

--- a/lib/square_up/resources/v2/customer_group.ex
+++ b/lib/square_up/resources/v2/customer_group.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.CustomerGroup do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_customer_group_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_customer_group_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_customer_group_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_customer_group_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_customer_group_response/0}
@@ -13,18 +14,21 @@ defmodule SquareUp.V2.CustomerGroup do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/groups"
     })
   end
 
-  @spec delete(SquareUp.Client.t(), %{required(:group_id) => binary()}, %{}) ::
+  @spec delete(SquareUp.Client.t(), %{required(:group_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.delete_customer_group_response())
-  def delete(client, path_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{group_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_customer_group_response/0}
@@ -32,18 +36,21 @@ defmodule SquareUp.V2.CustomerGroup do
     call(client, %{
       method: :delete,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/groups/{group_id}"
     })
   end
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:group_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:group_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_customer_group_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{group_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_customer_group_response/0}
@@ -51,8 +58,10 @@ defmodule SquareUp.V2.CustomerGroup do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/groups/{group_id}"
@@ -62,10 +71,12 @@ defmodule SquareUp.V2.CustomerGroup do
   @spec update(
           SquareUp.Client.t(),
           %{required(:group_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.update_customer_group_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_customer_group_response())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{group_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_customer_group_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_customer_group_response/0}
@@ -73,8 +84,10 @@ defmodule SquareUp.V2.CustomerGroup do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/groups/{group_id}"

--- a/lib/square_up/resources/v2/customer_group.ex
+++ b/lib/square_up/resources/v2/customer_group.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.CustomerGroup do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_customer_group_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_customer_group_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_customer_group_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_customer_group_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_customer_group_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/groups"
     })
@@ -26,21 +26,21 @@ defmodule SquareUp.V2.CustomerGroup do
 
   @spec delete(SquareUp.Client.t(), %{required(:group_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.delete_customer_group_response())
-  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{group_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_customer_group_response/0}
 
     call(client, %{
       method: :delete,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/groups/{group_id}"
     })
@@ -48,21 +48,21 @@ defmodule SquareUp.V2.CustomerGroup do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:group_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_customer_group_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{group_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_customer_group_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/groups/{group_id}"
     })
@@ -71,24 +71,24 @@ defmodule SquareUp.V2.CustomerGroup do
   @spec update(
           SquareUp.Client.t(),
           %{required(:group_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.update_customer_group_request()
+          SquareUp.TypeSpecs.update_customer_group_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_customer_group_response())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{group_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_customer_group_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_customer_group_response/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/groups/{group_id}"
     })

--- a/lib/square_up/resources/v2/customer_groups.ex
+++ b/lib/square_up/resources/v2/customer_groups.ex
@@ -2,19 +2,22 @@ defmodule SquareUp.V2.CustomerGroups do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{optional(:cursor) => binary()}) ::
+  @spec list(SquareUp.Client.t(), %{}, %{optional(:cursor) => binary()}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.list_customer_groups_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
-    params_spec = schema(%{cursor: spec(is_binary())})
+    query_params_spec = schema(%{cursor: spec(is_binary())})
+    params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_customer_groups_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/groups"

--- a/lib/square_up/resources/v2/customer_groups.ex
+++ b/lib/square_up/resources/v2/customer_groups.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.CustomerGroups do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{optional(:cursor) => binary()}, %{}) ::
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{optional(:cursor) => binary()}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.list_customer_groups_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{cursor: spec(is_binary())})
     params_spec = schema(%{})
+    query_params_spec = schema(%{cursor: spec(is_binary())})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_customer_groups_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/groups"
     })

--- a/lib/square_up/resources/v2/customer_segment.ex
+++ b/lib/square_up/resources/v2/customer_segment.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.CustomerSegment do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:segment_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_customer_segment_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{segment_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_customer_segment_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/segments/{segment_id}"
     })

--- a/lib/square_up/resources/v2/customer_segment.ex
+++ b/lib/square_up/resources/v2/customer_segment.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.CustomerSegment do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:segment_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:segment_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_customer_segment_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{segment_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_customer_segment_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.CustomerSegment do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/segments/{segment_id}"

--- a/lib/square_up/resources/v2/customer_segments.ex
+++ b/lib/square_up/resources/v2/customer_segments.ex
@@ -2,19 +2,22 @@ defmodule SquareUp.V2.CustomerSegments do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{optional(:cursor) => binary()}) ::
+  @spec list(SquareUp.Client.t(), %{}, %{optional(:cursor) => binary()}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.list_customer_segments_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
-    params_spec = schema(%{cursor: spec(is_binary())})
+    query_params_spec = schema(%{cursor: spec(is_binary())})
+    params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_customer_segments_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/segments"

--- a/lib/square_up/resources/v2/customer_segments.ex
+++ b/lib/square_up/resources/v2/customer_segments.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.CustomerSegments do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{optional(:cursor) => binary()}, %{}) ::
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{optional(:cursor) => binary()}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.list_customer_segments_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{cursor: spec(is_binary())})
     params_spec = schema(%{})
+    query_params_spec = schema(%{cursor: spec(is_binary())})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_customer_segments_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/segments"
     })

--- a/lib/square_up/resources/v2/customers.ex
+++ b/lib/square_up/resources/v2/customers.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Customers do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_customers_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_customers_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_customers_response())
-  def search(client, path_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_customers_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_customers_response/0}
@@ -13,36 +14,47 @@ defmodule SquareUp.V2.Customers do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers/search"
     })
   end
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          optional(:cursor) => binary(),
-          optional(:sort_field) => binary(),
-          optional(:sort_order) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_customers_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{
+            optional(:cursor) => binary(),
+            optional(:sort_field) => binary(),
+            optional(:sort_order) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_customers_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         cursor: spec(is_binary()),
         sort_field: spec(is_binary()),
         sort_order: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_customers_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/customers"

--- a/lib/square_up/resources/v2/customers.ex
+++ b/lib/square_up/resources/v2/customers.ex
@@ -2,40 +2,36 @@ defmodule SquareUp.V2.Customers do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_customers_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_customers_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_customers_response())
-  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_customers_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_customers_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers/search"
     })
   end
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{
-            optional(:cursor) => binary(),
-            optional(:sort_field) => binary(),
-            optional(:sort_order) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_customers_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          optional(:cursor) => binary(),
+          optional(:sort_field) => binary(),
+          optional(:sort_order) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_customers_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -44,18 +40,16 @@ defmodule SquareUp.V2.Customers do
         sort_order: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_customers_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/customers"
     })

--- a/lib/square_up/resources/v2/device_code.ex
+++ b/lib/square_up/resources/v2/device_code.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.DeviceCode do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec get(SquareUp.Client.t(), %{required(:id) => binary()}, %{}) ::
+  @spec get(SquareUp.Client.t(), %{required(:id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_device_code_response())
-  def get(client, path_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_device_code_response/0}
@@ -13,18 +14,21 @@ defmodule SquareUp.V2.DeviceCode do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/devices/codes/{id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_device_code_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_device_code_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_device_code_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_device_code_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_device_code_response/0}
@@ -32,8 +36,10 @@ defmodule SquareUp.V2.DeviceCode do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/devices/codes"

--- a/lib/square_up/resources/v2/device_code.ex
+++ b/lib/square_up/resources/v2/device_code.ex
@@ -4,43 +4,43 @@ defmodule SquareUp.V2.DeviceCode do
 
   @spec get(SquareUp.Client.t(), %{required(:id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_device_code_response())
-  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_device_code_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/devices/codes/{id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_device_code_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_device_code_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_device_code_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_device_code_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_device_code_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/devices/codes"
     })

--- a/lib/square_up/resources/v2/device_codes.ex
+++ b/lib/square_up/resources/v2/device_codes.ex
@@ -2,18 +2,14 @@ defmodule SquareUp.V2.DeviceCodes do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{
-            optional(:cursor) => binary(),
-            optional(:location_id) => binary(),
-            optional(:product_type) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_device_codes_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          optional(:cursor) => binary(),
+          optional(:location_id) => binary(),
+          optional(:product_type) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_device_codes_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -22,18 +18,16 @@ defmodule SquareUp.V2.DeviceCodes do
         product_type: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_device_codes_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/devices/codes"
     })

--- a/lib/square_up/resources/v2/device_codes.ex
+++ b/lib/square_up/resources/v2/device_codes.ex
@@ -2,28 +2,37 @@ defmodule SquareUp.V2.DeviceCodes do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          optional(:cursor) => binary(),
-          optional(:location_id) => binary(),
-          optional(:product_type) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_device_codes_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{
+            optional(:cursor) => binary(),
+            optional(:location_id) => binary(),
+            optional(:product_type) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_device_codes_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         cursor: spec(is_binary()),
         location_id: spec(is_binary()),
         product_type: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_device_codes_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/devices/codes"

--- a/lib/square_up/resources/v2/dispute.ex
+++ b/lib/square_up/resources/v2/dispute.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Dispute do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:dispute_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:dispute_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_dispute_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_dispute_response/0}
@@ -13,18 +14,21 @@ defmodule SquareUp.V2.Dispute do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}"
     })
   end
 
-  @spec accept(SquareUp.Client.t(), %{required(:dispute_id) => binary()}, %{}) ::
+  @spec accept(SquareUp.Client.t(), %{required(:dispute_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.accept_dispute_response())
-  def accept(client, path_params \\ %{}, params \\ %{}) do
+  def accept(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.accept_dispute_response/0}
@@ -32,8 +36,10 @@ defmodule SquareUp.V2.Dispute do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}/accept"

--- a/lib/square_up/resources/v2/dispute.ex
+++ b/lib/square_up/resources/v2/dispute.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.Dispute do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:dispute_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_dispute_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_dispute_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}"
     })
@@ -26,21 +26,21 @@ defmodule SquareUp.V2.Dispute do
 
   @spec accept(SquareUp.Client.t(), %{required(:dispute_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.accept_dispute_response())
-  def accept(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def accept(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.accept_dispute_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}/accept"
     })

--- a/lib/square_up/resources/v2/dispute_evidence.ex
+++ b/lib/square_up/resources/v2/dispute_evidence.ex
@@ -5,10 +5,12 @@ defmodule SquareUp.V2.DisputeEvidence do
   @spec remove(
           SquareUp.Client.t(),
           %{required(:dispute_id) => binary(), required(:evidence_id) => binary()},
+          %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.remove_dispute_evidence_response())
-  def remove(client, path_params \\ %{}, params \\ %{}) do
+  def remove(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary()), evidence_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.remove_dispute_evidence_response/0}
@@ -16,8 +18,10 @@ defmodule SquareUp.V2.DisputeEvidence do
     call(client, %{
       method: :delete,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}/evidence/{evidence_id}"
@@ -27,10 +31,12 @@ defmodule SquareUp.V2.DisputeEvidence do
   @spec retrieve(
           SquareUp.Client.t(),
           %{required(:dispute_id) => binary(), required(:evidence_id) => binary()},
+          %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_dispute_evidence_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary()), evidence_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_dispute_evidence_response/0}
@@ -38,18 +44,21 @@ defmodule SquareUp.V2.DisputeEvidence do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}/evidence/{evidence_id}"
     })
   end
 
-  @spec list(SquareUp.Client.t(), %{required(:dispute_id) => binary()}, %{}) ::
+  @spec list(SquareUp.Client.t(), %{required(:dispute_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.list_dispute_evidence_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_dispute_evidence_response/0}
@@ -57,8 +66,10 @@ defmodule SquareUp.V2.DisputeEvidence do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}/evidence"

--- a/lib/square_up/resources/v2/dispute_evidence.ex
+++ b/lib/square_up/resources/v2/dispute_evidence.ex
@@ -8,21 +8,21 @@ defmodule SquareUp.V2.DisputeEvidence do
           %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.remove_dispute_evidence_response())
-  def remove(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def remove(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary()), evidence_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.remove_dispute_evidence_response/0}
 
     call(client, %{
       method: :delete,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}/evidence/{evidence_id}"
     })
@@ -34,21 +34,21 @@ defmodule SquareUp.V2.DisputeEvidence do
           %{},
           %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_dispute_evidence_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary()), evidence_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_dispute_evidence_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}/evidence/{evidence_id}"
     })
@@ -56,21 +56,21 @@ defmodule SquareUp.V2.DisputeEvidence do
 
   @spec list(SquareUp.Client.t(), %{required(:dispute_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.list_dispute_evidence_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_dispute_evidence_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}/evidence"
     })

--- a/lib/square_up/resources/v2/dispute_evidence_text.ex
+++ b/lib/square_up/resources/v2/dispute_evidence_text.ex
@@ -5,26 +5,27 @@ defmodule SquareUp.V2.DisputeEvidenceText do
   @spec create(
           SquareUp.Client.t(),
           %{required(:dispute_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.create_dispute_evidence_text_request()
+          SquareUp.TypeSpecs.create_dispute_evidence_text_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.create_dispute_evidence_text_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary())})
-    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.create_dispute_evidence_text_request/0)
+
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_dispute_evidence_text_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}/evidence_text"
     })

--- a/lib/square_up/resources/v2/dispute_evidence_text.ex
+++ b/lib/square_up/resources/v2/dispute_evidence_text.ex
@@ -5,10 +5,12 @@ defmodule SquareUp.V2.DisputeEvidenceText do
   @spec create(
           SquareUp.Client.t(),
           %{required(:dispute_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.create_dispute_evidence_text_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.create_dispute_evidence_text_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary())})
+    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.create_dispute_evidence_text_request/0)
@@ -18,8 +20,10 @@ defmodule SquareUp.V2.DisputeEvidenceText do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}/evidence_text"

--- a/lib/square_up/resources/v2/disputes.ex
+++ b/lib/square_up/resources/v2/disputes.ex
@@ -2,18 +2,14 @@ defmodule SquareUp.V2.Disputes do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{
-            optional(:cursor) => binary(),
-            optional(:states) => binary(),
-            optional(:location_id) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_disputes_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          optional(:cursor) => binary(),
+          optional(:states) => binary(),
+          optional(:location_id) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_disputes_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -22,18 +18,16 @@ defmodule SquareUp.V2.Disputes do
         location_id: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_disputes_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/disputes"
     })

--- a/lib/square_up/resources/v2/disputes.ex
+++ b/lib/square_up/resources/v2/disputes.ex
@@ -2,28 +2,37 @@ defmodule SquareUp.V2.Disputes do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          optional(:cursor) => binary(),
-          optional(:states) => binary(),
-          optional(:location_id) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_disputes_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{
+            optional(:cursor) => binary(),
+            optional(:states) => binary(),
+            optional(:location_id) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_disputes_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         cursor: spec(is_binary()),
         states: spec(is_binary()),
         location_id: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_disputes_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/disputes"

--- a/lib/square_up/resources/v2/domain.ex
+++ b/lib/square_up/resources/v2/domain.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Domain do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec register(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.register_domain_request()) ::
+  @spec register(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.register_domain_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.register_domain_response())
-  def register(client, path_params \\ %{}, params \\ %{}) do
+  def register(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.register_domain_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.register_domain_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.Domain do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/apple-pay/domains"

--- a/lib/square_up/resources/v2/domain.ex
+++ b/lib/square_up/resources/v2/domain.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.Domain do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec register(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.register_domain_request()) ::
+  @spec register(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.register_domain_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.register_domain_response())
-  def register(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def register(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.register_domain_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.register_domain_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/apple-pay/domains"
     })

--- a/lib/square_up/resources/v2/evidence.ex
+++ b/lib/square_up/resources/v2/evidence.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.Evidence do
 
   @spec submit(SquareUp.Client.t(), %{required(:dispute_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.submit_evidence_response())
-  def submit(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def submit(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.submit_evidence_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}/submit-evidence"
     })

--- a/lib/square_up/resources/v2/evidence.ex
+++ b/lib/square_up/resources/v2/evidence.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Evidence do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec submit(SquareUp.Client.t(), %{required(:dispute_id) => binary()}, %{}) ::
+  @spec submit(SquareUp.Client.t(), %{required(:dispute_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.submit_evidence_response())
-  def submit(client, path_params \\ %{}, params \\ %{}) do
+  def submit(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{dispute_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.submit_evidence_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.Evidence do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/disputes/{dispute_id}/submit-evidence"

--- a/lib/square_up/resources/v2/info.ex
+++ b/lib/square_up/resources/v2/info.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Info do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec catalog(SquareUp.Client.t(), %{}, %{}) ::
+  @spec catalog(SquareUp.Client.t(), %{}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.catalog_info_response())
-  def catalog(client, path_params \\ %{}, params \\ %{}) do
+  def catalog(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.catalog_info_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.Info do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/info"

--- a/lib/square_up/resources/v2/info.ex
+++ b/lib/square_up/resources/v2/info.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.Info do
 
   @spec catalog(SquareUp.Client.t(), %{}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.catalog_info_response())
-  def catalog(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def catalog(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.catalog_info_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/info"
     })

--- a/lib/square_up/resources/v2/inventory_adjustment.ex
+++ b/lib/square_up/resources/v2/inventory_adjustment.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.InventoryAdjustment do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:adjustment_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_inventory_adjustment_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{adjustment_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_inventory_adjustment_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/adjustment/{adjustment_id}"
     })

--- a/lib/square_up/resources/v2/inventory_adjustment.ex
+++ b/lib/square_up/resources/v2/inventory_adjustment.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.InventoryAdjustment do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:adjustment_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:adjustment_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_inventory_adjustment_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{adjustment_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_inventory_adjustment_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.InventoryAdjustment do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/adjustment/{adjustment_id}"

--- a/lib/square_up/resources/v2/inventory_changes.ex
+++ b/lib/square_up/resources/v2/inventory_changes.ex
@@ -2,27 +2,25 @@ defmodule SquareUp.V2.InventoryChanges do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(
-          SquareUp.Client.t(),
-          %{required(:catalog_object_id) => binary()},
-          %{optional(:location_ids) => binary(), optional(:cursor) => binary()},
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_inventory_changes_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec retrieve(SquareUp.Client.t(), %{required(:catalog_object_id) => binary()}, %{}, %{
+          optional(:location_ids) => binary(),
+          optional(:cursor) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_inventory_changes_response())
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{catalog_object_id: spec(is_binary())})
-    query_params_spec = schema(%{location_ids: spec(is_binary()), cursor: spec(is_binary())})
     params_spec = schema(%{})
+    query_params_spec = schema(%{location_ids: spec(is_binary()), cursor: spec(is_binary())})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_inventory_changes_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/{catalog_object_id}/changes"
     })
@@ -31,16 +29,17 @@ defmodule SquareUp.V2.InventoryChanges do
   @spec batch_retrieve(
           SquareUp.Client.t(),
           %{},
-          %{},
-          SquareUp.TypeSpecs.batch_retrieve_inventory_changes_request()
+          SquareUp.TypeSpecs.batch_retrieve_inventory_changes_request(),
+          %{}
         ) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.batch_retrieve_inventory_changes_response())
-  def batch_retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def batch_retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.batch_retrieve_inventory_changes_request/0)
+
+    query_params_spec = schema(%{})
 
     response_spec =
       {:delegate, &SquareUp.ResponseSchema.batch_retrieve_inventory_changes_response/0}
@@ -48,11 +47,11 @@ defmodule SquareUp.V2.InventoryChanges do
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/batch-retrieve-changes"
     })

--- a/lib/square_up/resources/v2/inventory_changes.ex
+++ b/lib/square_up/resources/v2/inventory_changes.ex
@@ -2,21 +2,26 @@ defmodule SquareUp.V2.InventoryChanges do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:catalog_object_id) => binary()}, %{
-          optional(:location_ids) => binary(),
-          optional(:cursor) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_inventory_changes_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  @spec retrieve(
+          SquareUp.Client.t(),
+          %{required(:catalog_object_id) => binary()},
+          %{optional(:location_ids) => binary(), optional(:cursor) => binary()},
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_inventory_changes_response())
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{catalog_object_id: spec(is_binary())})
-    params_spec = schema(%{location_ids: spec(is_binary()), cursor: spec(is_binary())})
+    query_params_spec = schema(%{location_ids: spec(is_binary()), cursor: spec(is_binary())})
+    params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_inventory_changes_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/{catalog_object_id}/changes"
@@ -26,11 +31,13 @@ defmodule SquareUp.V2.InventoryChanges do
   @spec batch_retrieve(
           SquareUp.Client.t(),
           %{},
+          %{},
           SquareUp.TypeSpecs.batch_retrieve_inventory_changes_request()
         ) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.batch_retrieve_inventory_changes_response())
-  def batch_retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def batch_retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.batch_retrieve_inventory_changes_request/0)
@@ -41,8 +48,10 @@ defmodule SquareUp.V2.InventoryChanges do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/batch-retrieve-changes"

--- a/lib/square_up/resources/v2/inventory_count.ex
+++ b/lib/square_up/resources/v2/inventory_count.ex
@@ -2,21 +2,26 @@ defmodule SquareUp.V2.InventoryCount do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:catalog_object_id) => binary()}, %{
-          optional(:location_ids) => binary(),
-          optional(:cursor) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_inventory_count_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  @spec retrieve(
+          SquareUp.Client.t(),
+          %{required(:catalog_object_id) => binary()},
+          %{optional(:location_ids) => binary(), optional(:cursor) => binary()},
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_inventory_count_response())
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{catalog_object_id: spec(is_binary())})
-    params_spec = schema(%{location_ids: spec(is_binary()), cursor: spec(is_binary())})
+    query_params_spec = schema(%{location_ids: spec(is_binary()), cursor: spec(is_binary())})
+    params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_inventory_count_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/{catalog_object_id}"

--- a/lib/square_up/resources/v2/inventory_count.ex
+++ b/lib/square_up/resources/v2/inventory_count.ex
@@ -2,27 +2,25 @@ defmodule SquareUp.V2.InventoryCount do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(
-          SquareUp.Client.t(),
-          %{required(:catalog_object_id) => binary()},
-          %{optional(:location_ids) => binary(), optional(:cursor) => binary()},
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_inventory_count_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec retrieve(SquareUp.Client.t(), %{required(:catalog_object_id) => binary()}, %{}, %{
+          optional(:location_ids) => binary(),
+          optional(:cursor) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_inventory_count_response())
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{catalog_object_id: spec(is_binary())})
-    query_params_spec = schema(%{location_ids: spec(is_binary()), cursor: spec(is_binary())})
     params_spec = schema(%{})
+    query_params_spec = schema(%{location_ids: spec(is_binary()), cursor: spec(is_binary())})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_inventory_count_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/{catalog_object_id}"
     })

--- a/lib/square_up/resources/v2/inventory_counts.ex
+++ b/lib/square_up/resources/v2/inventory_counts.ex
@@ -5,11 +5,13 @@ defmodule SquareUp.V2.InventoryCounts do
   @spec batch_retrieve(
           SquareUp.Client.t(),
           %{},
+          %{},
           SquareUp.TypeSpecs.batch_retrieve_inventory_counts_request()
         ) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.batch_retrieve_inventory_counts_response())
-  def batch_retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def batch_retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.batch_retrieve_inventory_counts_request/0)
@@ -20,8 +22,10 @@ defmodule SquareUp.V2.InventoryCounts do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/batch-retrieve-counts"

--- a/lib/square_up/resources/v2/inventory_counts.ex
+++ b/lib/square_up/resources/v2/inventory_counts.ex
@@ -5,16 +5,17 @@ defmodule SquareUp.V2.InventoryCounts do
   @spec batch_retrieve(
           SquareUp.Client.t(),
           %{},
-          %{},
-          SquareUp.TypeSpecs.batch_retrieve_inventory_counts_request()
+          SquareUp.TypeSpecs.batch_retrieve_inventory_counts_request(),
+          %{}
         ) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.batch_retrieve_inventory_counts_response())
-  def batch_retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def batch_retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.batch_retrieve_inventory_counts_request/0)
+
+    query_params_spec = schema(%{})
 
     response_spec =
       {:delegate, &SquareUp.ResponseSchema.batch_retrieve_inventory_counts_response/0}
@@ -22,11 +23,11 @@ defmodule SquareUp.V2.InventoryCounts do
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/batch-retrieve-counts"
     })

--- a/lib/square_up/resources/v2/inventory_physical_count.ex
+++ b/lib/square_up/resources/v2/inventory_physical_count.ex
@@ -6,10 +6,10 @@ defmodule SquareUp.V2.InventoryPhysicalCount do
           SquareUp.Client.response(
             SquareUp.TypeSpecs.retrieve_inventory_physical_count_response()
           )
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{physical_count_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec =
       {:delegate, &SquareUp.ResponseSchema.retrieve_inventory_physical_count_response/0}
@@ -17,11 +17,11 @@ defmodule SquareUp.V2.InventoryPhysicalCount do
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/physical-count/{physical_count_id}"
     })

--- a/lib/square_up/resources/v2/inventory_physical_count.ex
+++ b/lib/square_up/resources/v2/inventory_physical_count.ex
@@ -2,12 +2,13 @@ defmodule SquareUp.V2.InventoryPhysicalCount do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:physical_count_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:physical_count_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(
             SquareUp.TypeSpecs.retrieve_inventory_physical_count_response()
           )
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{physical_count_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec =
@@ -16,8 +17,10 @@ defmodule SquareUp.V2.InventoryPhysicalCount do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/inventory/physical-count/{physical_count_id}"

--- a/lib/square_up/resources/v2/invoice.ex
+++ b/lib/square_up/resources/v2/invoice.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Invoice do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_invoice_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_invoice_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_invoice_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_invoice_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_invoice_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.Invoice do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/invoices"
@@ -24,10 +27,12 @@ defmodule SquareUp.V2.Invoice do
   @spec publish(
           SquareUp.Client.t(),
           %{required(:invoice_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.publish_invoice_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.publish_invoice_response())
-  def publish(client, path_params \\ %{}, params \\ %{}) do
+  def publish(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{invoice_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.publish_invoice_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.publish_invoice_response/0}
@@ -35,38 +40,47 @@ defmodule SquareUp.V2.Invoice do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/invoices/{invoice_id}/publish"
     })
   end
 
-  @spec delete(SquareUp.Client.t(), %{required(:invoice_id) => binary()}, %{
-          optional(:version) => integer()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.delete_invoice_response())
-  def delete(client, path_params \\ %{}, params \\ %{}) do
+  @spec delete(
+          SquareUp.Client.t(),
+          %{required(:invoice_id) => binary()},
+          %{optional(:version) => integer()},
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.delete_invoice_response())
+  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{invoice_id: spec(is_binary())})
-    params_spec = schema(%{version: spec(is_integer())})
+    query_params_spec = schema(%{version: spec(is_integer())})
+    params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_invoice_response/0}
 
     call(client, %{
       method: :delete,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/invoices/{invoice_id}"
     })
   end
 
-  @spec get(SquareUp.Client.t(), %{required(:invoice_id) => binary()}, %{}) ::
+  @spec get(SquareUp.Client.t(), %{required(:invoice_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_invoice_response())
-  def get(client, path_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{invoice_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_invoice_response/0}
@@ -74,8 +88,10 @@ defmodule SquareUp.V2.Invoice do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/invoices/{invoice_id}"
@@ -85,10 +101,12 @@ defmodule SquareUp.V2.Invoice do
   @spec update(
           SquareUp.Client.t(),
           %{required(:invoice_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.update_invoice_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_invoice_response())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{invoice_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_invoice_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_invoice_response/0}
@@ -96,8 +114,10 @@ defmodule SquareUp.V2.Invoice do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/invoices/{invoice_id}"
@@ -107,10 +127,12 @@ defmodule SquareUp.V2.Invoice do
   @spec cancel(
           SquareUp.Client.t(),
           %{required(:invoice_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.cancel_invoice_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.cancel_invoice_response())
-  def cancel(client, path_params \\ %{}, params \\ %{}) do
+  def cancel(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{invoice_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.cancel_invoice_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.cancel_invoice_response/0}
@@ -118,8 +140,10 @@ defmodule SquareUp.V2.Invoice do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/invoices/{invoice_id}/cancel"

--- a/lib/square_up/resources/v2/invoice.ex
+++ b/lib/square_up/resources/v2/invoice.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.Invoice do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_invoice_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_invoice_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_invoice_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_invoice_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_invoice_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/invoices"
     })
@@ -27,50 +27,47 @@ defmodule SquareUp.V2.Invoice do
   @spec publish(
           SquareUp.Client.t(),
           %{required(:invoice_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.publish_invoice_request()
+          SquareUp.TypeSpecs.publish_invoice_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.publish_invoice_response())
-  def publish(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def publish(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{invoice_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.publish_invoice_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.publish_invoice_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/invoices/{invoice_id}/publish"
     })
   end
 
-  @spec delete(
-          SquareUp.Client.t(),
-          %{required(:invoice_id) => binary()},
-          %{optional(:version) => integer()},
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.delete_invoice_response())
-  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec delete(SquareUp.Client.t(), %{required(:invoice_id) => binary()}, %{}, %{
+          optional(:version) => integer()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.delete_invoice_response())
+  def delete(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{invoice_id: spec(is_binary())})
-    query_params_spec = schema(%{version: spec(is_integer())})
     params_spec = schema(%{})
+    query_params_spec = schema(%{version: spec(is_integer())})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_invoice_response/0}
 
     call(client, %{
       method: :delete,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/invoices/{invoice_id}"
     })
@@ -78,21 +75,21 @@ defmodule SquareUp.V2.Invoice do
 
   @spec get(SquareUp.Client.t(), %{required(:invoice_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_invoice_response())
-  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{invoice_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_invoice_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/invoices/{invoice_id}"
     })
@@ -101,24 +98,24 @@ defmodule SquareUp.V2.Invoice do
   @spec update(
           SquareUp.Client.t(),
           %{required(:invoice_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.update_invoice_request()
+          SquareUp.TypeSpecs.update_invoice_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_invoice_response())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{invoice_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_invoice_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_invoice_response/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/invoices/{invoice_id}"
     })
@@ -127,24 +124,24 @@ defmodule SquareUp.V2.Invoice do
   @spec cancel(
           SquareUp.Client.t(),
           %{required(:invoice_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.cancel_invoice_request()
+          SquareUp.TypeSpecs.cancel_invoice_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.cancel_invoice_response())
-  def cancel(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def cancel(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{invoice_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.cancel_invoice_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.cancel_invoice_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/invoices/{invoice_id}/cancel"
     })

--- a/lib/square_up/resources/v2/invoices.ex
+++ b/lib/square_up/resources/v2/invoices.ex
@@ -2,40 +2,36 @@ defmodule SquareUp.V2.Invoices do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_invoices_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_invoices_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_invoices_response())
-  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_invoices_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_invoices_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/invoices/search"
     })
   end
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{
-            required(:location_id) => binary(),
-            optional(:cursor) => binary(),
-            optional(:limit) => integer()
-          },
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_invoices_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          required(:location_id) => binary(),
+          optional(:cursor) => binary(),
+          optional(:limit) => integer()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_invoices_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -44,18 +40,16 @@ defmodule SquareUp.V2.Invoices do
         limit: spec(is_integer())
       })
 
-    params_spec = schema(%{})
-
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_invoices_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/invoices"
     })

--- a/lib/square_up/resources/v2/invoices.ex
+++ b/lib/square_up/resources/v2/invoices.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Invoices do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_invoices_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_invoices_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_invoices_response())
-  def search(client, path_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_invoices_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_invoices_response/0}
@@ -13,36 +14,47 @@ defmodule SquareUp.V2.Invoices do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/invoices/search"
     })
   end
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          required(:location_id) => binary(),
-          optional(:cursor) => binary(),
-          optional(:limit) => integer()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_invoices_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{
+            required(:location_id) => binary(),
+            optional(:cursor) => binary(),
+            optional(:limit) => integer()
+          },
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_invoices_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         location_id: spec(is_binary()),
         cursor: spec(is_binary()),
         limit: spec(is_integer())
       })
 
+    params_spec = schema(%{})
+
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_invoices_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/invoices"

--- a/lib/square_up/resources/v2/item_modifier_lists.ex
+++ b/lib/square_up/resources/v2/item_modifier_lists.ex
@@ -2,10 +2,15 @@ defmodule SquareUp.V2.ItemModifierLists do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec update(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.update_item_modifier_lists_request()) ::
-          SquareUp.Client.response(SquareUp.TypeSpecs.update_item_modifier_lists_response())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  @spec update(
+          SquareUp.Client.t(),
+          %{},
+          %{},
+          SquareUp.TypeSpecs.update_item_modifier_lists_request()
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_item_modifier_lists_response())
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.update_item_modifier_lists_request/0)
@@ -15,8 +20,10 @@ defmodule SquareUp.V2.ItemModifierLists do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/update-item-modifier-lists"

--- a/lib/square_up/resources/v2/item_modifier_lists.ex
+++ b/lib/square_up/resources/v2/item_modifier_lists.ex
@@ -5,26 +5,27 @@ defmodule SquareUp.V2.ItemModifierLists do
   @spec update(
           SquareUp.Client.t(),
           %{},
-          %{},
-          SquareUp.TypeSpecs.update_item_modifier_lists_request()
+          SquareUp.TypeSpecs.update_item_modifier_lists_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_item_modifier_lists_response())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.update_item_modifier_lists_request/0)
+
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_item_modifier_lists_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/update-item-modifier-lists"
     })

--- a/lib/square_up/resources/v2/item_taxes.ex
+++ b/lib/square_up/resources/v2/item_taxes.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.ItemTaxes do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec update(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.update_item_taxes_request()) ::
+  @spec update(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.update_item_taxes_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.update_item_taxes_response())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_item_taxes_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_item_taxes_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/update-item-taxes"
     })

--- a/lib/square_up/resources/v2/item_taxes.ex
+++ b/lib/square_up/resources/v2/item_taxes.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.ItemTaxes do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec update(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.update_item_taxes_request()) ::
+  @spec update(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.update_item_taxes_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.update_item_taxes_response())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_item_taxes_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_item_taxes_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.ItemTaxes do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/update-item-taxes"

--- a/lib/square_up/resources/v2/location.ex
+++ b/lib/square_up/resources/v2/location.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Location do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_location_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_location_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_location_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_location_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_location_response/0}
@@ -13,18 +14,21 @@ defmodule SquareUp.V2.Location do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/locations"
     })
   end
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:location_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:location_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_location_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_location_response/0}
@@ -32,8 +36,10 @@ defmodule SquareUp.V2.Location do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/locations/{location_id}"
@@ -43,10 +49,12 @@ defmodule SquareUp.V2.Location do
   @spec update(
           SquareUp.Client.t(),
           %{required(:location_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.update_location_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_location_response())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_location_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_location_response/0}
@@ -54,8 +62,10 @@ defmodule SquareUp.V2.Location do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/locations/{location_id}"

--- a/lib/square_up/resources/v2/location.ex
+++ b/lib/square_up/resources/v2/location.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.Location do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_location_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_location_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_location_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_location_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_location_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/locations"
     })
@@ -26,21 +26,21 @@ defmodule SquareUp.V2.Location do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:location_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_location_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_location_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/locations/{location_id}"
     })
@@ -49,24 +49,24 @@ defmodule SquareUp.V2.Location do
   @spec update(
           SquareUp.Client.t(),
           %{required(:location_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.update_location_request()
+          SquareUp.TypeSpecs.update_location_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_location_response())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{location_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_location_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_location_response/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/locations/{location_id}"
     })

--- a/lib/square_up/resources/v2/locations.ex
+++ b/lib/square_up/resources/v2/locations.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Locations do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{}) ::
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.list_locations_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_locations_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.Locations do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/locations"

--- a/lib/square_up/resources/v2/locations.ex
+++ b/lib/square_up/resources/v2/locations.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.Locations do
 
   @spec list(SquareUp.Client.t(), %{}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.list_locations_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_locations_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/locations"
     })

--- a/lib/square_up/resources/v2/loyalty_account.ex
+++ b/lib/square_up/resources/v2/loyalty_account.ex
@@ -4,43 +4,43 @@ defmodule SquareUp.V2.LoyaltyAccount do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:account_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_loyalty_account_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{account_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_loyalty_account_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/accounts/{account_id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_loyalty_account_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_loyalty_account_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_loyalty_account_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_loyalty_account_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_loyalty_account_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/accounts"
     })

--- a/lib/square_up/resources/v2/loyalty_account.ex
+++ b/lib/square_up/resources/v2/loyalty_account.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.LoyaltyAccount do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:account_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:account_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_loyalty_account_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{account_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_loyalty_account_response/0}
@@ -13,18 +14,21 @@ defmodule SquareUp.V2.LoyaltyAccount do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/accounts/{account_id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_loyalty_account_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_loyalty_account_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_loyalty_account_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_loyalty_account_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_loyalty_account_response/0}
@@ -32,8 +36,10 @@ defmodule SquareUp.V2.LoyaltyAccount do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/accounts"

--- a/lib/square_up/resources/v2/loyalty_accounts.ex
+++ b/lib/square_up/resources/v2/loyalty_accounts.ex
@@ -5,24 +5,24 @@ defmodule SquareUp.V2.LoyaltyAccounts do
   @spec search(
           SquareUp.Client.t(),
           %{},
-          %{},
-          SquareUp.TypeSpecs.search_loyalty_accounts_request()
+          SquareUp.TypeSpecs.search_loyalty_accounts_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.search_loyalty_accounts_response())
-  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_loyalty_accounts_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_loyalty_accounts_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/accounts/search"
     })

--- a/lib/square_up/resources/v2/loyalty_accounts.ex
+++ b/lib/square_up/resources/v2/loyalty_accounts.ex
@@ -2,10 +2,15 @@ defmodule SquareUp.V2.LoyaltyAccounts do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_loyalty_accounts_request()) ::
-          SquareUp.Client.response(SquareUp.TypeSpecs.search_loyalty_accounts_response())
-  def search(client, path_params \\ %{}, params \\ %{}) do
+  @spec search(
+          SquareUp.Client.t(),
+          %{},
+          %{},
+          SquareUp.TypeSpecs.search_loyalty_accounts_request()
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.search_loyalty_accounts_response())
+  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_loyalty_accounts_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_loyalty_accounts_response/0}
@@ -13,8 +18,10 @@ defmodule SquareUp.V2.LoyaltyAccounts do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/accounts/search"

--- a/lib/square_up/resources/v2/loyalty_events.ex
+++ b/lib/square_up/resources/v2/loyalty_events.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.LoyaltyEvents do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_loyalty_events_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_loyalty_events_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_loyalty_events_response())
-  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_loyalty_events_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_loyalty_events_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/events/search"
     })

--- a/lib/square_up/resources/v2/loyalty_events.ex
+++ b/lib/square_up/resources/v2/loyalty_events.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.LoyaltyEvents do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_loyalty_events_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_loyalty_events_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_loyalty_events_response())
-  def search(client, path_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_loyalty_events_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_loyalty_events_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.LoyaltyEvents do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/events/search"

--- a/lib/square_up/resources/v2/loyalty_points.ex
+++ b/lib/square_up/resources/v2/loyalty_points.ex
@@ -5,24 +5,24 @@ defmodule SquareUp.V2.LoyaltyPoints do
   @spec calculate(
           SquareUp.Client.t(),
           %{required(:program_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.calculate_loyalty_points_request()
+          SquareUp.TypeSpecs.calculate_loyalty_points_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.calculate_loyalty_points_response())
-  def calculate(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def calculate(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{program_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.calculate_loyalty_points_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.calculate_loyalty_points_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/programs/{program_id}/calculate"
     })
@@ -31,24 +31,24 @@ defmodule SquareUp.V2.LoyaltyPoints do
   @spec accumulate(
           SquareUp.Client.t(),
           %{required(:account_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.accumulate_loyalty_points_request()
+          SquareUp.TypeSpecs.accumulate_loyalty_points_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.accumulate_loyalty_points_response())
-  def accumulate(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def accumulate(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{account_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.accumulate_loyalty_points_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.accumulate_loyalty_points_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/accounts/{account_id}/accumulate"
     })
@@ -57,24 +57,24 @@ defmodule SquareUp.V2.LoyaltyPoints do
   @spec adjust(
           SquareUp.Client.t(),
           %{required(:account_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.adjust_loyalty_points_request()
+          SquareUp.TypeSpecs.adjust_loyalty_points_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.adjust_loyalty_points_response())
-  def adjust(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def adjust(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{account_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.adjust_loyalty_points_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.adjust_loyalty_points_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/accounts/{account_id}/adjust"
     })

--- a/lib/square_up/resources/v2/loyalty_points.ex
+++ b/lib/square_up/resources/v2/loyalty_points.ex
@@ -5,10 +5,12 @@ defmodule SquareUp.V2.LoyaltyPoints do
   @spec calculate(
           SquareUp.Client.t(),
           %{required(:program_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.calculate_loyalty_points_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.calculate_loyalty_points_response())
-  def calculate(client, path_params \\ %{}, params \\ %{}) do
+  def calculate(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{program_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.calculate_loyalty_points_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.calculate_loyalty_points_response/0}
@@ -16,8 +18,10 @@ defmodule SquareUp.V2.LoyaltyPoints do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/programs/{program_id}/calculate"
@@ -27,10 +31,12 @@ defmodule SquareUp.V2.LoyaltyPoints do
   @spec accumulate(
           SquareUp.Client.t(),
           %{required(:account_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.accumulate_loyalty_points_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.accumulate_loyalty_points_response())
-  def accumulate(client, path_params \\ %{}, params \\ %{}) do
+  def accumulate(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{account_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.accumulate_loyalty_points_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.accumulate_loyalty_points_response/0}
@@ -38,8 +44,10 @@ defmodule SquareUp.V2.LoyaltyPoints do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/accounts/{account_id}/accumulate"
@@ -49,10 +57,12 @@ defmodule SquareUp.V2.LoyaltyPoints do
   @spec adjust(
           SquareUp.Client.t(),
           %{required(:account_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.adjust_loyalty_points_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.adjust_loyalty_points_response())
-  def adjust(client, path_params \\ %{}, params \\ %{}) do
+  def adjust(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{account_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.adjust_loyalty_points_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.adjust_loyalty_points_response/0}
@@ -60,8 +70,10 @@ defmodule SquareUp.V2.LoyaltyPoints do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/accounts/{account_id}/adjust"

--- a/lib/square_up/resources/v2/loyalty_programs.ex
+++ b/lib/square_up/resources/v2/loyalty_programs.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.LoyaltyPrograms do
 
   @spec list(SquareUp.Client.t(), %{}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.list_loyalty_programs_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_loyalty_programs_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/programs"
     })

--- a/lib/square_up/resources/v2/loyalty_programs.ex
+++ b/lib/square_up/resources/v2/loyalty_programs.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.LoyaltyPrograms do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{}) ::
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.list_loyalty_programs_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_loyalty_programs_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.LoyaltyPrograms do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/programs"

--- a/lib/square_up/resources/v2/loyalty_reward.ex
+++ b/lib/square_up/resources/v2/loyalty_reward.ex
@@ -5,24 +5,24 @@ defmodule SquareUp.V2.LoyaltyReward do
   @spec redeem(
           SquareUp.Client.t(),
           %{required(:reward_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.redeem_loyalty_reward_request()
+          SquareUp.TypeSpecs.redeem_loyalty_reward_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.redeem_loyalty_reward_response())
-  def redeem(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def redeem(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{reward_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.redeem_loyalty_reward_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.redeem_loyalty_reward_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/rewards/{reward_id}/redeem"
     })
@@ -30,21 +30,21 @@ defmodule SquareUp.V2.LoyaltyReward do
 
   @spec delete(SquareUp.Client.t(), %{required(:reward_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.delete_loyalty_reward_response())
-  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{reward_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_loyalty_reward_response/0}
 
     call(client, %{
       method: :delete,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/rewards/{reward_id}"
     })
@@ -52,43 +52,43 @@ defmodule SquareUp.V2.LoyaltyReward do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:reward_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_loyalty_reward_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{reward_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_loyalty_reward_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/rewards/{reward_id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_loyalty_reward_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_loyalty_reward_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_loyalty_reward_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_loyalty_reward_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_loyalty_reward_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/rewards"
     })

--- a/lib/square_up/resources/v2/loyalty_reward.ex
+++ b/lib/square_up/resources/v2/loyalty_reward.ex
@@ -5,10 +5,12 @@ defmodule SquareUp.V2.LoyaltyReward do
   @spec redeem(
           SquareUp.Client.t(),
           %{required(:reward_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.redeem_loyalty_reward_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.redeem_loyalty_reward_response())
-  def redeem(client, path_params \\ %{}, params \\ %{}) do
+  def redeem(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{reward_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.redeem_loyalty_reward_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.redeem_loyalty_reward_response/0}
@@ -16,18 +18,21 @@ defmodule SquareUp.V2.LoyaltyReward do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/rewards/{reward_id}/redeem"
     })
   end
 
-  @spec delete(SquareUp.Client.t(), %{required(:reward_id) => binary()}, %{}) ::
+  @spec delete(SquareUp.Client.t(), %{required(:reward_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.delete_loyalty_reward_response())
-  def delete(client, path_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{reward_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_loyalty_reward_response/0}
@@ -35,18 +40,21 @@ defmodule SquareUp.V2.LoyaltyReward do
     call(client, %{
       method: :delete,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/rewards/{reward_id}"
     })
   end
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:reward_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:reward_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_loyalty_reward_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{reward_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_loyalty_reward_response/0}
@@ -54,18 +62,21 @@ defmodule SquareUp.V2.LoyaltyReward do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/rewards/{reward_id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_loyalty_reward_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_loyalty_reward_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_loyalty_reward_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_loyalty_reward_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_loyalty_reward_response/0}
@@ -73,8 +84,10 @@ defmodule SquareUp.V2.LoyaltyReward do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/rewards"

--- a/lib/square_up/resources/v2/loyalty_rewards.ex
+++ b/lib/square_up/resources/v2/loyalty_rewards.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.LoyaltyRewards do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_loyalty_rewards_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_loyalty_rewards_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_loyalty_rewards_response())
-  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_loyalty_rewards_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_loyalty_rewards_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/rewards/search"
     })

--- a/lib/square_up/resources/v2/loyalty_rewards.ex
+++ b/lib/square_up/resources/v2/loyalty_rewards.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.LoyaltyRewards do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_loyalty_rewards_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_loyalty_rewards_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_loyalty_rewards_response())
-  def search(client, path_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_loyalty_rewards_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_loyalty_rewards_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.LoyaltyRewards do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/loyalty/rewards/search"

--- a/lib/square_up/resources/v2/merchant.ex
+++ b/lib/square_up/resources/v2/merchant.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.Merchant do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:merchant_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_merchant_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{merchant_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_merchant_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/merchants/{merchant_id}"
     })

--- a/lib/square_up/resources/v2/merchant.ex
+++ b/lib/square_up/resources/v2/merchant.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Merchant do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:merchant_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:merchant_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_merchant_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{merchant_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_merchant_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.Merchant do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/merchants/{merchant_id}"

--- a/lib/square_up/resources/v2/merchants.ex
+++ b/lib/square_up/resources/v2/merchants.ex
@@ -2,19 +2,22 @@ defmodule SquareUp.V2.Merchants do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{optional(:cursor) => integer()}) ::
+  @spec list(SquareUp.Client.t(), %{}, %{optional(:cursor) => integer()}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.list_merchants_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
-    params_spec = schema(%{cursor: spec(is_integer())})
+    query_params_spec = schema(%{cursor: spec(is_integer())})
+    params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_merchants_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/merchants"

--- a/lib/square_up/resources/v2/merchants.ex
+++ b/lib/square_up/resources/v2/merchants.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.Merchants do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{optional(:cursor) => integer()}, %{}) ::
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{optional(:cursor) => integer()}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.list_merchants_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{cursor: spec(is_integer())})
     params_spec = schema(%{})
+    query_params_spec = schema(%{cursor: spec(is_integer())})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_merchants_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/merchants"
     })

--- a/lib/square_up/resources/v2/order.ex
+++ b/lib/square_up/resources/v2/order.ex
@@ -5,10 +5,12 @@ defmodule SquareUp.V2.Order do
   @spec update(
           SquareUp.Client.t(),
           %{required(:order_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.update_order_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_order_response())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{order_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_order_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_order_response/0}
@@ -16,18 +18,21 @@ defmodule SquareUp.V2.Order do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/orders/{order_id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_order_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_order_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_order_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_order_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_order_response/0}
@@ -35,18 +40,21 @@ defmodule SquareUp.V2.Order do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/orders"
     })
   end
 
-  @spec calculate(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.calculate_order_request()) ::
+  @spec calculate(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.calculate_order_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.calculate_order_response())
-  def calculate(client, path_params \\ %{}, params \\ %{}) do
+  def calculate(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.calculate_order_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.calculate_order_response/0}
@@ -54,8 +62,10 @@ defmodule SquareUp.V2.Order do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/orders/calculate"
@@ -65,10 +75,12 @@ defmodule SquareUp.V2.Order do
   @spec pay(
           SquareUp.Client.t(),
           %{required(:order_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.pay_order_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.pay_order_response())
-  def pay(client, path_params \\ %{}, params \\ %{}) do
+  def pay(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{order_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.pay_order_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.pay_order_response/0}
@@ -76,8 +88,10 @@ defmodule SquareUp.V2.Order do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/orders/{order_id}/pay"

--- a/lib/square_up/resources/v2/order.ex
+++ b/lib/square_up/resources/v2/order.ex
@@ -5,68 +5,68 @@ defmodule SquareUp.V2.Order do
   @spec update(
           SquareUp.Client.t(),
           %{required(:order_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.update_order_request()
+          SquareUp.TypeSpecs.update_order_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_order_response())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{order_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_order_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_order_response/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/orders/{order_id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_order_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_order_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_order_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_order_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_order_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/orders"
     })
   end
 
-  @spec calculate(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.calculate_order_request()) ::
+  @spec calculate(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.calculate_order_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.calculate_order_response())
-  def calculate(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def calculate(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.calculate_order_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.calculate_order_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/orders/calculate"
     })
@@ -75,24 +75,24 @@ defmodule SquareUp.V2.Order do
   @spec pay(
           SquareUp.Client.t(),
           %{required(:order_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.pay_order_request()
+          SquareUp.TypeSpecs.pay_order_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.pay_order_response())
-  def pay(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def pay(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{order_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.pay_order_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.pay_order_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/orders/{order_id}/pay"
     })

--- a/lib/square_up/resources/v2/orders.ex
+++ b/lib/square_up/resources/v2/orders.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.Orders do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_orders_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_orders_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_orders_response())
-  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_orders_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_orders_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/orders/search"
     })
@@ -27,24 +27,24 @@ defmodule SquareUp.V2.Orders do
   @spec batch_retrieve(
           SquareUp.Client.t(),
           %{},
-          %{},
-          SquareUp.TypeSpecs.batch_retrieve_orders_request()
+          SquareUp.TypeSpecs.batch_retrieve_orders_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.batch_retrieve_orders_response())
-  def batch_retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def batch_retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.batch_retrieve_orders_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.batch_retrieve_orders_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/orders/batch-retrieve"
     })

--- a/lib/square_up/resources/v2/orders.ex
+++ b/lib/square_up/resources/v2/orders.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Orders do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_orders_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_orders_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_orders_response())
-  def search(client, path_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_orders_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_orders_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.Orders do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/orders/search"
@@ -24,10 +27,12 @@ defmodule SquareUp.V2.Orders do
   @spec batch_retrieve(
           SquareUp.Client.t(),
           %{},
+          %{},
           SquareUp.TypeSpecs.batch_retrieve_orders_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.batch_retrieve_orders_response())
-  def batch_retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def batch_retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.batch_retrieve_orders_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.batch_retrieve_orders_response/0}
@@ -35,8 +40,10 @@ defmodule SquareUp.V2.Orders do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/orders/batch-retrieve"

--- a/lib/square_up/resources/v2/payment.ex
+++ b/lib/square_up/resources/v2/payment.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Payment do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec refund(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.refund_payment_request()) ::
+  @spec refund(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.refund_payment_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.refund_payment_response())
-  def refund(client, path_params \\ %{}, params \\ %{}) do
+  def refund(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.refund_payment_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.refund_payment_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.Payment do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/refunds"
@@ -24,13 +27,15 @@ defmodule SquareUp.V2.Payment do
   @spec cancel_by_idempotency_key(
           SquareUp.Client.t(),
           %{},
+          %{},
           SquareUp.TypeSpecs.cancel_payment_by_idempotency_key_request()
         ) ::
           SquareUp.Client.response(
             SquareUp.TypeSpecs.cancel_payment_by_idempotency_key_response()
           )
-  def cancel_by_idempotency_key(client, path_params \\ %{}, params \\ %{}) do
+  def cancel_by_idempotency_key(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.cancel_payment_by_idempotency_key_request/0)
@@ -41,18 +46,21 @@ defmodule SquareUp.V2.Payment do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/payments/cancel"
     })
   end
 
-  @spec complete(SquareUp.Client.t(), %{required(:payment_id) => binary()}, %{}) ::
+  @spec complete(SquareUp.Client.t(), %{required(:payment_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.complete_payment_response())
-  def complete(client, path_params \\ %{}, params \\ %{}) do
+  def complete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{payment_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.complete_payment_response/0}
@@ -60,18 +68,21 @@ defmodule SquareUp.V2.Payment do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/payments/{payment_id}/complete"
     })
   end
 
-  @spec get(SquareUp.Client.t(), %{required(:payment_id) => binary()}, %{}) ::
+  @spec get(SquareUp.Client.t(), %{required(:payment_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_payment_response())
-  def get(client, path_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{payment_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_payment_response/0}
@@ -79,18 +90,21 @@ defmodule SquareUp.V2.Payment do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/payments/{payment_id}"
     })
   end
 
-  @spec cancel(SquareUp.Client.t(), %{required(:payment_id) => binary()}, %{}) ::
+  @spec cancel(SquareUp.Client.t(), %{required(:payment_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.cancel_payment_response())
-  def cancel(client, path_params \\ %{}, params \\ %{}) do
+  def cancel(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{payment_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.cancel_payment_response/0}
@@ -98,18 +112,21 @@ defmodule SquareUp.V2.Payment do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/payments/{payment_id}/cancel"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_payment_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_payment_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_payment_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_payment_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_payment_response/0}
@@ -117,8 +134,10 @@ defmodule SquareUp.V2.Payment do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/payments"

--- a/lib/square_up/resources/v2/payment.ex
+++ b/lib/square_up/resources/v2/payment.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.Payment do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec refund(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.refund_payment_request()) ::
+  @spec refund(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.refund_payment_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.refund_payment_response())
-  def refund(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def refund(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.refund_payment_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.refund_payment_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/refunds"
     })
@@ -27,18 +27,19 @@ defmodule SquareUp.V2.Payment do
   @spec cancel_by_idempotency_key(
           SquareUp.Client.t(),
           %{},
-          %{},
-          SquareUp.TypeSpecs.cancel_payment_by_idempotency_key_request()
+          SquareUp.TypeSpecs.cancel_payment_by_idempotency_key_request(),
+          %{}
         ) ::
           SquareUp.Client.response(
             SquareUp.TypeSpecs.cancel_payment_by_idempotency_key_response()
           )
-  def cancel_by_idempotency_key(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def cancel_by_idempotency_key(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.cancel_payment_by_idempotency_key_request/0)
+
+    query_params_spec = schema(%{})
 
     response_spec =
       {:delegate, &SquareUp.ResponseSchema.cancel_payment_by_idempotency_key_response/0}
@@ -46,11 +47,11 @@ defmodule SquareUp.V2.Payment do
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/payments/cancel"
     })
@@ -58,21 +59,21 @@ defmodule SquareUp.V2.Payment do
 
   @spec complete(SquareUp.Client.t(), %{required(:payment_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.complete_payment_response())
-  def complete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def complete(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{payment_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.complete_payment_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/payments/{payment_id}/complete"
     })
@@ -80,21 +81,21 @@ defmodule SquareUp.V2.Payment do
 
   @spec get(SquareUp.Client.t(), %{required(:payment_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_payment_response())
-  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{payment_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_payment_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/payments/{payment_id}"
     })
@@ -102,43 +103,43 @@ defmodule SquareUp.V2.Payment do
 
   @spec cancel(SquareUp.Client.t(), %{required(:payment_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.cancel_payment_response())
-  def cancel(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def cancel(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{payment_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.cancel_payment_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/payments/{payment_id}/cancel"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_payment_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_payment_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_payment_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_payment_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_payment_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/payments"
     })

--- a/lib/square_up/resources/v2/payment_refund.ex
+++ b/lib/square_up/resources/v2/payment_refund.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.PaymentRefund do
 
   @spec get(SquareUp.Client.t(), %{required(:refund_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_payment_refund_response())
-  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{refund_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_payment_refund_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/refunds/{refund_id}"
     })

--- a/lib/square_up/resources/v2/payment_refund.ex
+++ b/lib/square_up/resources/v2/payment_refund.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.PaymentRefund do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec get(SquareUp.Client.t(), %{required(:refund_id) => binary()}, %{}) ::
+  @spec get(SquareUp.Client.t(), %{required(:refund_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_payment_refund_response())
-  def get(client, path_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{refund_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_payment_refund_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.PaymentRefund do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/refunds/{refund_id}"

--- a/lib/square_up/resources/v2/payment_refunds.ex
+++ b/lib/square_up/resources/v2/payment_refunds.ex
@@ -2,22 +2,18 @@ defmodule SquareUp.V2.PaymentRefunds do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{
-            optional(:begin_time) => binary(),
-            optional(:end_time) => binary(),
-            optional(:sort_order) => binary(),
-            optional(:cursor) => binary(),
-            optional(:location_id) => binary(),
-            optional(:status) => binary(),
-            optional(:source_type) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_payment_refunds_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          optional(:begin_time) => binary(),
+          optional(:end_time) => binary(),
+          optional(:sort_order) => binary(),
+          optional(:cursor) => binary(),
+          optional(:location_id) => binary(),
+          optional(:status) => binary(),
+          optional(:source_type) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_payment_refunds_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -30,18 +26,16 @@ defmodule SquareUp.V2.PaymentRefunds do
         source_type: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_payment_refunds_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/refunds"
     })

--- a/lib/square_up/resources/v2/payment_refunds.ex
+++ b/lib/square_up/resources/v2/payment_refunds.ex
@@ -2,19 +2,24 @@ defmodule SquareUp.V2.PaymentRefunds do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          optional(:begin_time) => binary(),
-          optional(:end_time) => binary(),
-          optional(:sort_order) => binary(),
-          optional(:cursor) => binary(),
-          optional(:location_id) => binary(),
-          optional(:status) => binary(),
-          optional(:source_type) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_payment_refunds_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{
+            optional(:begin_time) => binary(),
+            optional(:end_time) => binary(),
+            optional(:sort_order) => binary(),
+            optional(:cursor) => binary(),
+            optional(:location_id) => binary(),
+            optional(:status) => binary(),
+            optional(:source_type) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_payment_refunds_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         begin_time: spec(is_binary()),
         end_time: spec(is_binary()),
@@ -25,13 +30,17 @@ defmodule SquareUp.V2.PaymentRefunds do
         source_type: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_payment_refunds_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/refunds"

--- a/lib/square_up/resources/v2/payments.ex
+++ b/lib/square_up/resources/v2/payments.ex
@@ -2,23 +2,19 @@ defmodule SquareUp.V2.Payments do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{
-            optional(:begin_time) => binary(),
-            optional(:end_time) => binary(),
-            optional(:sort_order) => binary(),
-            optional(:cursor) => binary(),
-            optional(:location_id) => binary(),
-            optional(:total) => integer(),
-            optional(:last_4) => binary(),
-            optional(:card_brand) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_payments_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          optional(:begin_time) => binary(),
+          optional(:end_time) => binary(),
+          optional(:sort_order) => binary(),
+          optional(:cursor) => binary(),
+          optional(:location_id) => binary(),
+          optional(:total) => integer(),
+          optional(:last_4) => binary(),
+          optional(:card_brand) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_payments_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -32,18 +28,16 @@ defmodule SquareUp.V2.Payments do
         card_brand: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_payments_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/payments"
     })

--- a/lib/square_up/resources/v2/payments.ex
+++ b/lib/square_up/resources/v2/payments.ex
@@ -2,20 +2,25 @@ defmodule SquareUp.V2.Payments do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          optional(:begin_time) => binary(),
-          optional(:end_time) => binary(),
-          optional(:sort_order) => binary(),
-          optional(:cursor) => binary(),
-          optional(:location_id) => binary(),
-          optional(:total) => integer(),
-          optional(:last_4) => binary(),
-          optional(:card_brand) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_payments_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{
+            optional(:begin_time) => binary(),
+            optional(:end_time) => binary(),
+            optional(:sort_order) => binary(),
+            optional(:cursor) => binary(),
+            optional(:location_id) => binary(),
+            optional(:total) => integer(),
+            optional(:last_4) => binary(),
+            optional(:card_brand) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_payments_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         begin_time: spec(is_binary()),
         end_time: spec(is_binary()),
@@ -27,13 +32,17 @@ defmodule SquareUp.V2.Payments do
         card_brand: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_payments_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/payments"

--- a/lib/square_up/resources/v2/shift.ex
+++ b/lib/square_up/resources/v2/shift.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.Shift do
 
   @spec delete(SquareUp.Client.t(), %{required(:id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.delete_shift_response())
-  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_shift_response/0}
 
     call(client, %{
       method: :delete,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/shifts/{id}"
     })
@@ -26,21 +26,21 @@ defmodule SquareUp.V2.Shift do
 
   @spec get(SquareUp.Client.t(), %{required(:id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_shift_response())
-  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_shift_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/shifts/{id}"
     })
@@ -49,46 +49,46 @@ defmodule SquareUp.V2.Shift do
   @spec update(
           SquareUp.Client.t(),
           %{required(:id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.update_shift_request()
+          SquareUp.TypeSpecs.update_shift_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_shift_response())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_shift_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_shift_response/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/shifts/{id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_shift_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_shift_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_shift_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_shift_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_shift_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/shifts"
     })

--- a/lib/square_up/resources/v2/shift.ex
+++ b/lib/square_up/resources/v2/shift.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Shift do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec delete(SquareUp.Client.t(), %{required(:id) => binary()}, %{}) ::
+  @spec delete(SquareUp.Client.t(), %{required(:id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.delete_shift_response())
-  def delete(client, path_params \\ %{}, params \\ %{}) do
+  def delete(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.delete_shift_response/0}
@@ -13,18 +14,21 @@ defmodule SquareUp.V2.Shift do
     call(client, %{
       method: :delete,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/shifts/{id}"
     })
   end
 
-  @spec get(SquareUp.Client.t(), %{required(:id) => binary()}, %{}) ::
+  @spec get(SquareUp.Client.t(), %{required(:id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_shift_response())
-  def get(client, path_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_shift_response/0}
@@ -32,8 +36,10 @@ defmodule SquareUp.V2.Shift do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/shifts/{id}"
@@ -43,10 +49,12 @@ defmodule SquareUp.V2.Shift do
   @spec update(
           SquareUp.Client.t(),
           %{required(:id) => binary()},
+          %{},
           SquareUp.TypeSpecs.update_shift_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_shift_response())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_shift_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_shift_response/0}
@@ -54,18 +62,21 @@ defmodule SquareUp.V2.Shift do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/shifts/{id}"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_shift_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_shift_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_shift_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_shift_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_shift_response/0}
@@ -73,8 +84,10 @@ defmodule SquareUp.V2.Shift do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/shifts"

--- a/lib/square_up/resources/v2/shifts.ex
+++ b/lib/square_up/resources/v2/shifts.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Shifts do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_shifts_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_shifts_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_shifts_response())
-  def search(client, path_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_shifts_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_shifts_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.Shifts do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/shifts/search"

--- a/lib/square_up/resources/v2/shifts.ex
+++ b/lib/square_up/resources/v2/shifts.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.Shifts do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_shifts_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_shifts_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_shifts_response())
-  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_shifts_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_shifts_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/shifts/search"
     })

--- a/lib/square_up/resources/v2/subscription.ex
+++ b/lib/square_up/resources/v2/subscription.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.Subscription do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:subscription_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_subscription_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{subscription_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_subscription_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/subscriptions/{subscription_id}"
     })
@@ -27,24 +27,24 @@ defmodule SquareUp.V2.Subscription do
   @spec update(
           SquareUp.Client.t(),
           %{required(:subscription_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.update_subscription_request()
+          SquareUp.TypeSpecs.update_subscription_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_subscription_response())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{subscription_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_subscription_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_subscription_response/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/subscriptions/{subscription_id}"
     })
@@ -52,43 +52,43 @@ defmodule SquareUp.V2.Subscription do
 
   @spec cancel(SquareUp.Client.t(), %{required(:subscription_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.cancel_subscription_response())
-  def cancel(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def cancel(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{subscription_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.cancel_subscription_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/subscriptions/{subscription_id}/cancel"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_subscription_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_subscription_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_subscription_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_subscription_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_subscription_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/subscriptions"
     })

--- a/lib/square_up/resources/v2/subscription.ex
+++ b/lib/square_up/resources/v2/subscription.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Subscription do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:subscription_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:subscription_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_subscription_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{subscription_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_subscription_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.Subscription do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/subscriptions/{subscription_id}"
@@ -24,10 +27,12 @@ defmodule SquareUp.V2.Subscription do
   @spec update(
           SquareUp.Client.t(),
           %{required(:subscription_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.update_subscription_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_subscription_response())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{subscription_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_subscription_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_subscription_response/0}
@@ -35,18 +40,21 @@ defmodule SquareUp.V2.Subscription do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/subscriptions/{subscription_id}"
     })
   end
 
-  @spec cancel(SquareUp.Client.t(), %{required(:subscription_id) => binary()}, %{}) ::
+  @spec cancel(SquareUp.Client.t(), %{required(:subscription_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.cancel_subscription_response())
-  def cancel(client, path_params \\ %{}, params \\ %{}) do
+  def cancel(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{subscription_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.cancel_subscription_response/0}
@@ -54,18 +62,21 @@ defmodule SquareUp.V2.Subscription do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/subscriptions/{subscription_id}/cancel"
     })
   end
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_subscription_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_subscription_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_subscription_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_subscription_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_subscription_response/0}
@@ -73,8 +84,10 @@ defmodule SquareUp.V2.Subscription do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/subscriptions"

--- a/lib/square_up/resources/v2/subscription_events.ex
+++ b/lib/square_up/resources/v2/subscription_events.ex
@@ -2,21 +2,26 @@ defmodule SquareUp.V2.SubscriptionEvents do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{required(:subscription_id) => binary()}, %{
-          optional(:cursor) => binary(),
-          optional(:limit) => integer()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_subscription_events_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{required(:subscription_id) => binary()},
+          %{optional(:cursor) => binary(), optional(:limit) => integer()},
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_subscription_events_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{subscription_id: spec(is_binary())})
-    params_spec = schema(%{cursor: spec(is_binary()), limit: spec(is_integer())})
+    query_params_spec = schema(%{cursor: spec(is_binary()), limit: spec(is_integer())})
+    params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_subscription_events_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/subscriptions/{subscription_id}/events"

--- a/lib/square_up/resources/v2/subscription_events.ex
+++ b/lib/square_up/resources/v2/subscription_events.ex
@@ -2,27 +2,25 @@ defmodule SquareUp.V2.SubscriptionEvents do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{required(:subscription_id) => binary()},
-          %{optional(:cursor) => binary(), optional(:limit) => integer()},
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_subscription_events_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{required(:subscription_id) => binary()}, %{}, %{
+          optional(:cursor) => binary(),
+          optional(:limit) => integer()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_subscription_events_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{subscription_id: spec(is_binary())})
-    query_params_spec = schema(%{cursor: spec(is_binary()), limit: spec(is_integer())})
     params_spec = schema(%{})
+    query_params_spec = schema(%{cursor: spec(is_binary()), limit: spec(is_integer())})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_subscription_events_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/subscriptions/{subscription_id}/events"
     })

--- a/lib/square_up/resources/v2/subscriptions.ex
+++ b/lib/square_up/resources/v2/subscriptions.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.Subscriptions do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_subscriptions_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_subscriptions_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_subscriptions_response())
-  def search(client, path_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_subscriptions_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_subscriptions_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.Subscriptions do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/subscriptions/search"

--- a/lib/square_up/resources/v2/subscriptions.ex
+++ b/lib/square_up/resources/v2/subscriptions.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.Subscriptions do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_subscriptions_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_subscriptions_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_subscriptions_response())
-  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_subscriptions_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_subscriptions_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/subscriptions/search"
     })

--- a/lib/square_up/resources/v2/team_member.ex
+++ b/lib/square_up/resources/v2/team_member.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.TeamMember do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_team_member_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_team_member_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_team_member_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_team_member_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_team_member_response/0}
@@ -13,18 +14,21 @@ defmodule SquareUp.V2.TeamMember do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/team-members"
     })
   end
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:team_member_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:team_member_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_team_member_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{team_member_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_team_member_response/0}
@@ -32,8 +36,10 @@ defmodule SquareUp.V2.TeamMember do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/{team_member_id}"
@@ -43,10 +49,12 @@ defmodule SquareUp.V2.TeamMember do
   @spec update(
           SquareUp.Client.t(),
           %{required(:team_member_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.update_team_member_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_team_member_response())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{team_member_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_team_member_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_team_member_response/0}
@@ -54,8 +62,10 @@ defmodule SquareUp.V2.TeamMember do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/{team_member_id}"

--- a/lib/square_up/resources/v2/team_member.ex
+++ b/lib/square_up/resources/v2/team_member.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.TeamMember do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec create(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.create_team_member_request()) ::
+  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_team_member_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.create_team_member_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_team_member_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_team_member_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/team-members"
     })
@@ -26,21 +26,21 @@ defmodule SquareUp.V2.TeamMember do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:team_member_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_team_member_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{team_member_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_team_member_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/{team_member_id}"
     })
@@ -49,24 +49,24 @@ defmodule SquareUp.V2.TeamMember do
   @spec update(
           SquareUp.Client.t(),
           %{required(:team_member_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.update_team_member_request()
+          SquareUp.TypeSpecs.update_team_member_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_team_member_response())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{team_member_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_team_member_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_team_member_response/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/{team_member_id}"
     })

--- a/lib/square_up/resources/v2/team_member_wage.ex
+++ b/lib/square_up/resources/v2/team_member_wage.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.TeamMemberWage do
 
   @spec get(SquareUp.Client.t(), %{required(:id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_team_member_wage_response())
-  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_team_member_wage_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/team-member-wages/{id}"
     })

--- a/lib/square_up/resources/v2/team_member_wage.ex
+++ b/lib/square_up/resources/v2/team_member_wage.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.TeamMemberWage do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec get(SquareUp.Client.t(), %{required(:id) => binary()}, %{}) ::
+  @spec get(SquareUp.Client.t(), %{required(:id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_team_member_wage_response())
-  def get(client, path_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_team_member_wage_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.TeamMemberWage do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/team-member-wages/{id}"

--- a/lib/square_up/resources/v2/team_member_wages.ex
+++ b/lib/square_up/resources/v2/team_member_wages.ex
@@ -2,18 +2,14 @@ defmodule SquareUp.V2.TeamMemberWages do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{
-            optional(:team_member_id) => binary(),
-            optional(:limit) => integer(),
-            optional(:cursor) => binary()
-          },
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_team_member_wages_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          optional(:team_member_id) => binary(),
+          optional(:limit) => integer(),
+          optional(:cursor) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_team_member_wages_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
+    params_spec = schema(%{})
 
     query_params_spec =
       schema(%{
@@ -22,18 +18,16 @@ defmodule SquareUp.V2.TeamMemberWages do
         cursor: spec(is_binary())
       })
 
-    params_spec = schema(%{})
-
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_team_member_wages_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/team-member-wages"
     })

--- a/lib/square_up/resources/v2/team_member_wages.ex
+++ b/lib/square_up/resources/v2/team_member_wages.ex
@@ -2,28 +2,37 @@ defmodule SquareUp.V2.TeamMemberWages do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          optional(:team_member_id) => binary(),
-          optional(:limit) => integer(),
-          optional(:cursor) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_team_member_wages_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{
+            optional(:team_member_id) => binary(),
+            optional(:limit) => integer(),
+            optional(:cursor) => binary()
+          },
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_team_member_wages_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
 
-    params_spec =
+    query_params_spec =
       schema(%{
         team_member_id: spec(is_binary()),
         limit: spec(is_integer()),
         cursor: spec(is_binary())
       })
 
+    params_spec = schema(%{})
+
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_team_member_wages_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/team-member-wages"

--- a/lib/square_up/resources/v2/team_members.ex
+++ b/lib/square_up/resources/v2/team_members.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.TeamMembers do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_team_members_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_team_members_request()) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_team_members_response())
-  def search(client, path_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_team_members_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_team_members_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.TeamMembers do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/search"
@@ -24,10 +27,12 @@ defmodule SquareUp.V2.TeamMembers do
   @spec bulk_update(
           SquareUp.Client.t(),
           %{},
+          %{},
           SquareUp.TypeSpecs.bulk_update_team_members_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.bulk_update_team_members_response())
-  def bulk_update(client, path_params \\ %{}, params \\ %{}) do
+  def bulk_update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.bulk_update_team_members_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.bulk_update_team_members_response/0}
@@ -35,8 +40,10 @@ defmodule SquareUp.V2.TeamMembers do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/bulk-update"

--- a/lib/square_up/resources/v2/team_members.ex
+++ b/lib/square_up/resources/v2/team_members.ex
@@ -2,23 +2,23 @@ defmodule SquareUp.V2.TeamMembers do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, %{}, SquareUp.TypeSpecs.search_team_members_request()) ::
+  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_team_members_request(), %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.search_team_members_response())
-  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_team_members_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_team_members_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/search"
     })
@@ -27,24 +27,24 @@ defmodule SquareUp.V2.TeamMembers do
   @spec bulk_update(
           SquareUp.Client.t(),
           %{},
-          %{},
-          SquareUp.TypeSpecs.bulk_update_team_members_request()
+          SquareUp.TypeSpecs.bulk_update_team_members_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.bulk_update_team_members_response())
-  def bulk_update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def bulk_update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.bulk_update_team_members_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.bulk_update_team_members_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/bulk-update"
     })

--- a/lib/square_up/resources/v2/terminal_checkout.ex
+++ b/lib/square_up/resources/v2/terminal_checkout.ex
@@ -5,24 +5,24 @@ defmodule SquareUp.V2.TerminalCheckout do
   @spec create(
           SquareUp.Client.t(),
           %{},
-          %{},
-          SquareUp.TypeSpecs.create_terminal_checkout_request()
+          SquareUp.TypeSpecs.create_terminal_checkout_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.create_terminal_checkout_response())
-  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def create(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_terminal_checkout_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_terminal_checkout_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/terminals/checkouts"
     })
@@ -30,21 +30,21 @@ defmodule SquareUp.V2.TerminalCheckout do
 
   @spec get(SquareUp.Client.t(), %{required(:checkout_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_terminal_checkout_response())
-  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{checkout_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_terminal_checkout_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/terminals/checkouts/{checkout_id}"
     })
@@ -52,21 +52,21 @@ defmodule SquareUp.V2.TerminalCheckout do
 
   @spec cancel(SquareUp.Client.t(), %{required(:checkout_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.cancel_terminal_checkout_response())
-  def cancel(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def cancel(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{checkout_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.cancel_terminal_checkout_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/terminals/checkouts/{checkout_id}/cancel"
     })

--- a/lib/square_up/resources/v2/terminal_checkout.ex
+++ b/lib/square_up/resources/v2/terminal_checkout.ex
@@ -2,10 +2,15 @@ defmodule SquareUp.V2.TerminalCheckout do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec create(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.create_terminal_checkout_request()) ::
-          SquareUp.Client.response(SquareUp.TypeSpecs.create_terminal_checkout_response())
-  def create(client, path_params \\ %{}, params \\ %{}) do
+  @spec create(
+          SquareUp.Client.t(),
+          %{},
+          %{},
+          SquareUp.TypeSpecs.create_terminal_checkout_request()
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.create_terminal_checkout_response())
+  def create(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.create_terminal_checkout_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.create_terminal_checkout_response/0}
@@ -13,18 +18,21 @@ defmodule SquareUp.V2.TerminalCheckout do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/terminals/checkouts"
     })
   end
 
-  @spec get(SquareUp.Client.t(), %{required(:checkout_id) => binary()}, %{}) ::
+  @spec get(SquareUp.Client.t(), %{required(:checkout_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.get_terminal_checkout_response())
-  def get(client, path_params \\ %{}, params \\ %{}) do
+  def get(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{checkout_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.get_terminal_checkout_response/0}
@@ -32,18 +40,21 @@ defmodule SquareUp.V2.TerminalCheckout do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/terminals/checkouts/{checkout_id}"
     })
   end
 
-  @spec cancel(SquareUp.Client.t(), %{required(:checkout_id) => binary()}, %{}) ::
+  @spec cancel(SquareUp.Client.t(), %{required(:checkout_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.cancel_terminal_checkout_response())
-  def cancel(client, path_params \\ %{}, params \\ %{}) do
+  def cancel(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{checkout_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.cancel_terminal_checkout_response/0}
@@ -51,8 +62,10 @@ defmodule SquareUp.V2.TerminalCheckout do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/terminals/checkouts/{checkout_id}/cancel"

--- a/lib/square_up/resources/v2/terminal_checkouts.ex
+++ b/lib/square_up/resources/v2/terminal_checkouts.ex
@@ -2,10 +2,15 @@ defmodule SquareUp.V2.TerminalCheckouts do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec search(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.search_terminal_checkouts_request()) ::
-          SquareUp.Client.response(SquareUp.TypeSpecs.search_terminal_checkouts_response())
-  def search(client, path_params \\ %{}, params \\ %{}) do
+  @spec search(
+          SquareUp.Client.t(),
+          %{},
+          %{},
+          SquareUp.TypeSpecs.search_terminal_checkouts_request()
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.search_terminal_checkouts_response())
+  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_terminal_checkouts_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_terminal_checkouts_response/0}
@@ -13,8 +18,10 @@ defmodule SquareUp.V2.TerminalCheckouts do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/terminals/checkouts/search"

--- a/lib/square_up/resources/v2/terminal_checkouts.ex
+++ b/lib/square_up/resources/v2/terminal_checkouts.ex
@@ -5,24 +5,24 @@ defmodule SquareUp.V2.TerminalCheckouts do
   @spec search(
           SquareUp.Client.t(),
           %{},
-          %{},
-          SquareUp.TypeSpecs.search_terminal_checkouts_request()
+          SquareUp.TypeSpecs.search_terminal_checkouts_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.search_terminal_checkouts_response())
-  def search(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def search(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.search_terminal_checkouts_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.search_terminal_checkouts_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/terminals/checkouts/search"
     })

--- a/lib/square_up/resources/v2/upsert_catalog_objects.ex
+++ b/lib/square_up/resources/v2/upsert_catalog_objects.ex
@@ -5,26 +5,27 @@ defmodule SquareUp.V2.UpsertCatalogObjects do
   @spec batch(
           SquareUp.Client.t(),
           %{},
-          %{},
-          SquareUp.TypeSpecs.batch_upsert_catalog_objects_request()
+          SquareUp.TypeSpecs.batch_upsert_catalog_objects_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.batch_upsert_catalog_objects_response())
-  def batch(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def batch(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.batch_upsert_catalog_objects_request/0)
+
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.batch_upsert_catalog_objects_response/0}
 
     call(client, %{
       method: :post,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/batch-upsert"
     })

--- a/lib/square_up/resources/v2/upsert_catalog_objects.ex
+++ b/lib/square_up/resources/v2/upsert_catalog_objects.ex
@@ -2,10 +2,15 @@ defmodule SquareUp.V2.UpsertCatalogObjects do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec batch(SquareUp.Client.t(), %{}, SquareUp.TypeSpecs.batch_upsert_catalog_objects_request()) ::
-          SquareUp.Client.response(SquareUp.TypeSpecs.batch_upsert_catalog_objects_response())
-  def batch(client, path_params \\ %{}, params \\ %{}) do
+  @spec batch(
+          SquareUp.Client.t(),
+          %{},
+          %{},
+          SquareUp.TypeSpecs.batch_upsert_catalog_objects_request()
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.batch_upsert_catalog_objects_response())
+  def batch(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     params_spec =
       Norm.Delegate.delegate(&SquareUp.NormSchema.batch_upsert_catalog_objects_request/0)
@@ -15,8 +20,10 @@ defmodule SquareUp.V2.UpsertCatalogObjects do
     call(client, %{
       method: :post,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/catalog/batch-upsert"

--- a/lib/square_up/resources/v2/wage_setting.ex
+++ b/lib/square_up/resources/v2/wage_setting.ex
@@ -4,21 +4,21 @@ defmodule SquareUp.V2.WageSetting do
 
   @spec retrieve(SquareUp.Client.t(), %{required(:team_member_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_wage_setting_response())
-  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{team_member_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = schema(%{})
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_wage_setting_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/{team_member_id}/wage-setting"
     })
@@ -27,24 +27,24 @@ defmodule SquareUp.V2.WageSetting do
   @spec update(
           SquareUp.Client.t(),
           %{required(:team_member_id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.update_wage_setting_request()
+          SquareUp.TypeSpecs.update_wage_setting_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_wage_setting_response())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{team_member_id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_wage_setting_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_wage_setting_response/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/{team_member_id}/wage-setting"
     })

--- a/lib/square_up/resources/v2/wage_setting.ex
+++ b/lib/square_up/resources/v2/wage_setting.ex
@@ -2,10 +2,11 @@ defmodule SquareUp.V2.WageSetting do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec retrieve(SquareUp.Client.t(), %{required(:team_member_id) => binary()}, %{}) ::
+  @spec retrieve(SquareUp.Client.t(), %{required(:team_member_id) => binary()}, %{}, %{}) ::
           SquareUp.Client.response(SquareUp.TypeSpecs.retrieve_wage_setting_response())
-  def retrieve(client, path_params \\ %{}, params \\ %{}) do
+  def retrieve(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{team_member_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.retrieve_wage_setting_response/0}
@@ -13,8 +14,10 @@ defmodule SquareUp.V2.WageSetting do
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/{team_member_id}/wage-setting"
@@ -24,10 +27,12 @@ defmodule SquareUp.V2.WageSetting do
   @spec update(
           SquareUp.Client.t(),
           %{required(:team_member_id) => binary()},
+          %{},
           SquareUp.TypeSpecs.update_wage_setting_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_wage_setting_response())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{team_member_id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_wage_setting_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_wage_setting_response/0}
@@ -35,8 +40,10 @@ defmodule SquareUp.V2.WageSetting do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/team-members/{team_member_id}/wage-setting"

--- a/lib/square_up/resources/v2/workweek_config.ex
+++ b/lib/square_up/resources/v2/workweek_config.ex
@@ -5,10 +5,12 @@ defmodule SquareUp.V2.WorkweekConfig do
   @spec update(
           SquareUp.Client.t(),
           %{required(:id) => binary()},
+          %{},
           SquareUp.TypeSpecs.update_workweek_config_request()
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_workweek_config_response())
-  def update(client, path_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
+    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_workweek_config_request/0)
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_workweek_config_response/0}
@@ -16,8 +18,10 @@ defmodule SquareUp.V2.WorkweekConfig do
     call(client, %{
       method: :put,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/workweek-configs/{id}"

--- a/lib/square_up/resources/v2/workweek_config.ex
+++ b/lib/square_up/resources/v2/workweek_config.ex
@@ -5,24 +5,24 @@ defmodule SquareUp.V2.WorkweekConfig do
   @spec update(
           SquareUp.Client.t(),
           %{required(:id) => binary()},
-          %{},
-          SquareUp.TypeSpecs.update_workweek_config_request()
+          SquareUp.TypeSpecs.update_workweek_config_request(),
+          %{}
         ) :: SquareUp.Client.response(SquareUp.TypeSpecs.update_workweek_config_response())
-  def update(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  def update(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{id: spec(is_binary())})
-    query_params_spec = schema(%{})
     params_spec = Norm.Delegate.delegate(&SquareUp.NormSchema.update_workweek_config_request/0)
+    query_params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.update_workweek_config_response/0}
 
     call(client, %{
       method: :put,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/workweek-configs/{id}"
     })

--- a/lib/square_up/resources/v2/workweek_configs.ex
+++ b/lib/square_up/resources/v2/workweek_configs.ex
@@ -2,21 +2,26 @@ defmodule SquareUp.V2.WorkweekConfigs do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(SquareUp.Client.t(), %{}, %{
-          optional(:limit) => integer(),
-          optional(:cursor) => binary()
-        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_workweek_configs_response())
-  def list(client, path_params \\ %{}, params \\ %{}) do
+  @spec list(
+          SquareUp.Client.t(),
+          %{},
+          %{optional(:limit) => integer(), optional(:cursor) => binary()},
+          %{}
+        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_workweek_configs_response())
+  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
     path_params_spec = schema(%{})
-    params_spec = schema(%{limit: spec(is_integer()), cursor: spec(is_binary())})
+    query_params_spec = schema(%{limit: spec(is_integer()), cursor: spec(is_binary())})
+    params_spec = schema(%{})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_workweek_configs_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
+      query_params: query_params,
       params: params,
       path_params_spec: path_params_spec,
+      query_params_spec: query_params_spec,
       params_spec: params_spec,
       response_spec: response_spec,
       path: "/v2/labor/workweek-configs"

--- a/lib/square_up/resources/v2/workweek_configs.ex
+++ b/lib/square_up/resources/v2/workweek_configs.ex
@@ -2,27 +2,25 @@ defmodule SquareUp.V2.WorkweekConfigs do
   import Norm
   import SquareUp.Client, only: [call: 2]
 
-  @spec list(
-          SquareUp.Client.t(),
-          %{},
-          %{optional(:limit) => integer(), optional(:cursor) => binary()},
-          %{}
-        ) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_workweek_configs_response())
-  def list(client, path_params \\ %{}, query_params \\ %{}, params \\ %{}) do
+  @spec list(SquareUp.Client.t(), %{}, %{}, %{
+          optional(:limit) => integer(),
+          optional(:cursor) => binary()
+        }) :: SquareUp.Client.response(SquareUp.TypeSpecs.list_workweek_configs_response())
+  def list(client, path_params \\ %{}, params \\ %{}, query_params \\ %{}) do
     path_params_spec = schema(%{})
-    query_params_spec = schema(%{limit: spec(is_integer()), cursor: spec(is_binary())})
     params_spec = schema(%{})
+    query_params_spec = schema(%{limit: spec(is_integer()), cursor: spec(is_binary())})
 
     response_spec = {:delegate, &SquareUp.ResponseSchema.list_workweek_configs_response/0}
 
     call(client, %{
       method: :get,
       path_params: path_params,
-      query_params: query_params,
       params: params,
+      query_params: query_params,
       path_params_spec: path_params_spec,
-      query_params_spec: query_params_spec,
       params_spec: params_spec,
+      query_params_spec: query_params_spec,
       response_spec: response_spec,
       path: "/v2/labor/workweek-configs"
     })

--- a/scripts/gen_resources.ex
+++ b/scripts/gen_resources.ex
@@ -82,23 +82,23 @@ defmodule GenResources do
 
     """
       @spec #{function}(SquareUp.Client.t(), #{params_to_typespec(path_params)}, #{
-      params_to_typespec(query_params)}, #{params_to_typespec(params)
+      params_to_typespec(params)}, #{params_to_typespec(query_params)
     }) :: SquareUp.Client.response(#{params_to_typespec(success_response)})
-      def #{function}(client, path_params \\\\ %{}, query_params \\\\ %{}, params \\\\ %{}) do
+      def #{function}(client, path_params \\\\ %{}, params \\\\ %{}, query_params \\\\ %{}) do
         path_params_spec = #{params_to_norm(path_params)}
-        query_params_spec = #{params_to_norm(query_params)}
         params_spec = #{params_to_norm(params)}
+        query_params_spec = #{params_to_norm(query_params)}
 
         response_spec = #{response_to_spec(success_response)}
 
         call(client, %{
           method: :#{method},
           path_params: path_params,
-          query_params: query_params,
           params: params,
+          query_params: query_params,
           path_params_spec: path_params_spec,
-          query_params_spec: query_params_spec,
           params_spec: params_spec,
+          query_params_spec: query_params_spec,
           response_spec: response_spec,
           path: "#{path}"
         })

--- a/scripts/gen_resources.ex
+++ b/scripts/gen_resources.ex
@@ -82,7 +82,7 @@ defmodule GenResources do
 
     """
       @spec #{function}(SquareUp.Client.t(), #{params_to_typespec(path_params)}, #{
-      params_to_typespec(params)
+      params_to_typespec(query_params)}, #{params_to_typespec(params)
     }) :: SquareUp.Client.response(#{params_to_typespec(success_response)})
       def #{function}(client, path_params \\\\ %{}, query_params \\\\ %{}, params \\\\ %{}) do
         path_params_spec = #{params_to_norm(path_params)}

--- a/scripts/gen_resources.ex
+++ b/scripts/gen_resources.ex
@@ -20,7 +20,7 @@ defmodule GenResources do
   end
 
   defp rm_resources() do
-    Path.wildcard("lib/square_up/resources/*.ex")
+    Path.wildcard("lib/square_up/resources/**/*.ex")
     |> Enum.each(&File.rm/1)
   end
 
@@ -63,12 +63,20 @@ defmodule GenResources do
   end
 
   defp write_function({{_module, function}, {path, method, defn}}) do
-    {path_params, params} =
+    {path_params, other_params} =
       Map.get(defn, "parameters")
       |> Enum.split_with(fn
         %{"in" => "path"} -> true
         _ -> false
       end)
+
+    {params, query_params} =
+      other_params
+      |> Enum.split_with(fn
+        %{"in" => "body"} -> true
+        _ -> false
+      end)
+
 
     success_response = Map.get(defn, "responses") |> Map.get("200") |> Map.get("schema")
 
@@ -76,8 +84,9 @@ defmodule GenResources do
       @spec #{function}(SquareUp.Client.t(), #{params_to_typespec(path_params)}, #{
       params_to_typespec(params)
     }) :: SquareUp.Client.response(#{params_to_typespec(success_response)})
-      def #{function}(client, path_params \\\\ %{}, params \\\\ %{}) do
+      def #{function}(client, path_params \\\\ %{}, query_params \\\\ %{}, params \\\\ %{}) do
         path_params_spec = #{params_to_norm(path_params)}
+        query_params_spec = #{params_to_norm(query_params)}
         params_spec = #{params_to_norm(params)}
 
         response_spec = #{response_to_spec(success_response)}
@@ -85,8 +94,10 @@ defmodule GenResources do
         call(client, %{
           method: :#{method},
           path_params: path_params,
+          query_params: query_params,
           params: params,
           path_params_spec: path_params_spec,
+          query_params_spec: query_params_spec,
           params_spec: params_spec,
           response_spec: response_spec,
           path: "#{path}"

--- a/test/square_up_test.exs
+++ b/test/square_up_test.exs
@@ -10,12 +10,12 @@ defmodule SquareUpTest do
 
   test "rejects an invalid request" do
     assert {:error, [%{input: "foo", path: [:amount_money, :amount], spec: "is_integer()"} | _]} =
-             SquareUp.V2.Payment.create(@client, %{}, %{amount_money: %{amount: "foo"}})
+             SquareUp.V2.Payment.create(@client, %{}, %{}, %{amount_money: %{amount: "foo"}})
   end
 
   test "create and retrieve a customer" do
     {:ok, %{customer: %{id: customer_id}}} =
-      SquareUp.V2.Customer.create(@client, %{}, %{
+      SquareUp.V2.Customer.create(@client, %{}, %{}, %{
         given_name: "Derek",
         family_name: "Kraan"
       })

--- a/test/square_up_test.exs
+++ b/test/square_up_test.exs
@@ -10,12 +10,12 @@ defmodule SquareUpTest do
 
   test "rejects an invalid request" do
     assert {:error, [%{input: "foo", path: [:amount_money, :amount], spec: "is_integer()"} | _]} =
-             SquareUp.V2.Payment.create(@client, %{}, %{}, %{amount_money: %{amount: "foo"}})
+             SquareUp.V2.Payment.create(@client, %{}, %{amount_money: %{amount: "foo"}})
   end
 
   test "create and retrieve a customer" do
     {:ok, %{customer: %{id: customer_id}}} =
-      SquareUp.V2.Customer.create(@client, %{}, %{}, %{
+      SquareUp.V2.Customer.create(@client, %{}, %{
         given_name: "Derek",
         family_name: "Kraan"
       })


### PR DESCRIPTION
A lot of changes in this PR but they all stem from changes to `gen_resources.ex`.  Query params (`"in": "query"` in `api.json`) were being lumped in with body params. This adds them as a separate argument to the functions. 

I added it as the fourth argument and, like the other parameter arguments, it is optional (ie. the functions all have `query_params \\ %{}`).  This way any existing function calls that use the `/3` version of the function (such as the existing tests) are not broken.

Not exactly sure how to add tests for this.